### PR TITLE
Use only one build dir

### DIFF
--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -956,7 +956,7 @@ if exist %instdir%\%msys2%\mingw64\lib\xvidcore.dll.a (
 Setlocal DisableDelayedExpansion
 
 if %build32%==yes (
-    if not exist %instdir%\build32 mkdir %instdir%\build32
+    if not exist %instdir%\build mkdir %instdir%\build
     if not exist %instdir%\local32\share (
         echo.-------------------------------------------------------------------------------
         echo.create local32 folders
@@ -975,7 +975,7 @@ if %build32%==yes (
     )
 
 if %build64%==yes (
-    if not exist %instdir%\build64 mkdir %instdir%\build64
+    if not exist %instdir%\build mkdir %instdir%\build
     if not exist %instdir%\local64\share (
         echo.-------------------------------------------------------------------------------
         echo.create local64 folders
@@ -1022,10 +1022,9 @@ if "%searchRes%"=="local64" GOTO writeProfile32
     (
         echo.
         echo.%instdir%\local32\ /local32
-        echo.%instdir%\build32\ /build32
+        echo.%instdir%\build\ /build
         echo.%instdir%\%msys2%\mingw32\ /mingw32
         echo.%instdir%\local64\ /local64
-        echo.%instdir%\build64\ /build64
         echo.%instdir%\%msys2%\mingw64\ /mingw64
         )>>%instdir%\%msys2%\etc\fstab.
 
@@ -1076,7 +1075,7 @@ if %build32%==yes (
             echo.export PATH PS1
             echo.
             echo.# package build directory
-            echo.LOCALBUILDDIR=/build32
+            echo.LOCALBUILDDIR=/build
             echo.# package installation prefix
             echo.LOCALDESTDIR=/local32
             echo.export LOCALBUILDDIR LOCALDESTDIR
@@ -1131,7 +1130,7 @@ if %build64%==yes (
             echo.export PATH PS1
             echo.
             echo.# package build directory
-            echo.LOCALBUILDDIR=/build64
+            echo.LOCALBUILDDIR=/build
             echo.# package installation prefix
             echo.LOCALDESTDIR=/local64
             echo.export LOCALBUILDDIR LOCALDESTDIR

--- a/media-suite_compile.sh
+++ b/media-suite_compile.sh
@@ -51,15 +51,19 @@ if [ ! -d $gitFolder ]; then
     git clone $gitDepth -b $gitBranch $gitURL $gitFolder
     compile="true"
     cd $gitFolder
+    touch recently_updated
 else
     cd $gitFolder
-    oldHead=`git rev-parse HEAD`
     git reset --quiet --hard @{u}
+    oldHead=`git rev-parse HEAD`
     git pull origin $gitBranch
     newHead=`git rev-parse HEAD`
 
     if [[ "$oldHead" != "$newHead" ]]; then
         compile="true"
+        touch recently_updated
+    elif [[ -f recently_updated ]] && [[ ! -f build_successful$bits ]]; then
+            compile="true"
     fi
 fi
 }
@@ -81,6 +85,9 @@ else
 
     if [[ "$oldRevision" != "$newRevision" ]]; then
         compile="true"
+        touch recently_updated
+    elif [[ -f recently_updated ]] && [[ ! -f build_successful$bits ]]; then
+            compile="true"
     fi
 fi
 }
@@ -103,6 +110,9 @@ else
 
     if [[ "$oldHead" != "$newHead" ]]; then
         compile="true"
+        touch recently_updated
+    elif [[ -f recently_updated ]] && [[ ! -f build_successful$bits ]]; then
+            compile="true"
     fi
 fi
 }
@@ -140,6 +150,8 @@ do_checkIfExist() {
                         fi
                     fi
                 fi
+            else
+                touch build_successful$bits
             fi
             else
                 echo -------------------------------------------------
@@ -165,6 +177,8 @@ do_checkIfExist() {
                         fi
                     fi
                 fi
+            else
+                touch build_successful$bits
             fi
             else
                 echo -------------------------------------------------
@@ -2209,6 +2223,9 @@ if [[ $build64 = "yes" ]]; then
     echo "-------------------------------------------------------------------------------"
     sleep 3
 fi
+
+find /build -maxdepth 2 -name recently_updated -delete
+find /build -maxdepth 2 -name build_successful* -delete
 
 echo -ne "\033]0;compiling done...\007"
 echo


### PR DESCRIPTION
Only tested this with my usecase (64-bit only).
Will test with 32-bit as well tomorrow.

The separate "build_successful$bits" mean that in case something happens during 64-bit compilation the 32-bit won't get compiled again.