### PR TITLE
Optional apps

### DIFF
--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -310,6 +310,7 @@ if %x265INI%==0 (
     echo. Build x265 [H.265 encoder] binary?
     echo. 1 = Yes [static]
     echo. 2 = Build library only
+    echo. 3 = No
     echo.
     echo -------------------------------------------------------------------------------
     echo -------------------------------------------------------------------------------
@@ -323,9 +324,12 @@ if %buildx265%==1 (
     set "x265=y"
     )
 if %buildx265%==2 (
+    set "x265=l"
+    )
+if %buildx265%==3 (
     set "x265=n"
     )
-if %buildx265% GTR 2 GOTO x265
+if %buildx265% GTR 3 GOTO x265
 if %writex265%==yes echo.x265=^%buildx265%>>%ini%
 
 :other265

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -58,6 +58,7 @@ if exist %ini% GOTO checkINI
     set archINI=0
     set freeINI=0
     set ffmbcINI=0
+    set vpxINI=0
     set x264INI=0
     set x265INI=0
     set other265INI=0
@@ -84,6 +85,8 @@ findstr /i "arch" %ini% > nul
 findstr /i "free" %ini% > nul
     if ERRORLEVEL 1 del %ini% && GOTO selectmsys2Arch
 findstr /i "ffmbc" %ini% > nul
+    if ERRORLEVEL 1 del %ini% && GOTO selectmsys2Arch
+findstr /i "vpx" %ini% > nul
     if ERRORLEVEL 1 del %ini% && GOTO selectmsys2Arch
 findstr /i "x264" %ini% > nul
     if ERRORLEVEL 1 del %ini% && GOTO selectmsys2Arch
@@ -121,6 +124,7 @@ for /F "tokens=2 delims==" %%a in ('findstr /i "msys2Arch" %ini%') do set msys2A
 for /F "tokens=2 delims==" %%j in ('findstr /i "arch" %ini%') do set archINI=%%j
 for /F "tokens=2 delims==" %%b in ('findstr /i "free" %ini%') do set freeINI=%%b
 for /F "tokens=2 delims==" %%f in ('findstr /i "ffmbc" %ini%') do set ffmbcINI=%%f
+for /F "tokens=2 delims==" %%f in ('findstr /i "vpx" %ini%') do set vpxINI=%%f
 for /F "tokens=2 delims==" %%f in ('findstr /i "x264" %ini%') do set x264INI=%%f
 for /F "tokens=2 delims==" %%f in ('findstr /i "x265" %ini%') do set x265INI=%%f
 for /F "tokens=2 delims==" %%f in ('findstr /i "other265" %ini%') do set other265INI=%%f
@@ -234,6 +238,37 @@ if %buildffmbc%==2 (
     )
 if %buildffmbc% GTR 2 GOTO ffmbc
 if %writeBC%==yes echo.ffmbc=^%buildffmbc%>>%ini%
+
+:vpx
+set "writevpx=no"
+if %vpxINI%==0 (
+    echo -------------------------------------------------------------------------------
+    echo -------------------------------------------------------------------------------
+    echo.
+    echo. Build vpx [VP8/VP9 encoder] binary?
+    echo. 1 = Yes [static]
+    echo. 2 = Build library only
+    echo. 3 = No
+    echo.
+    echo -------------------------------------------------------------------------------
+    echo -------------------------------------------------------------------------------
+    set /P buildvpx="Build vpx: "
+    set "writevpx=yes"
+    ) else (
+        set buildvpx=%vpxINI%
+        )
+
+if %buildvpx%==1 (
+    set "vpx=y"
+    )
+if %buildvpx%==2 (
+    set "vpx=l"
+    )
+if %buildvpx%==3 (
+    set "vpx=n"
+    )
+if %buildvpx% GTR 3 GOTO vpx
+if %writevpx%==yes echo.vpx=^%buildvpx%>>%ini%
 
 :x264
 set "writex264=no"
@@ -1251,6 +1286,6 @@ IF ERRORLEVEL == 1 (
     pause
   )
 
-start %instdir%\%msys2%\usr\bin\mintty.exe -i /msys2.ico /usr/bin/bash --login %instdir%\media-suite_compile.sh --cpuCount=%cpuCount% --build32=%build32% --build64=%build64% --deleteSource=%deleteSource% --mp4box=%mp4box% --ffmbc=%ffmbc% --x264=%x264% --x265=%x265% --other265=%other265% --mediainfo=%mediainfo% --sox=%sox% --ffmpeg=%ffmpeg% --ffmpegUpdate=%ffmpegUpdate% --mplayer=%mplayer% --mpv=%mpv% --mkv=%mkv% --nonfree=%binary%  --stripping=%stripFile% --packing=%packFile%
+start %instdir%\%msys2%\usr\bin\mintty.exe -i /msys2.ico /usr/bin/bash --login %instdir%\media-suite_compile.sh --cpuCount=%cpuCount% --build32=%build32% --build64=%build64% --deleteSource=%deleteSource% --mp4box=%mp4box% --ffmbc=%ffmbc% --vpx=%vpx% --x264=%x264% --x265=%x265% --other265=%other265% --mediainfo=%mediainfo% --sox=%sox% --ffmpeg=%ffmpeg% --ffmpegUpdate=%ffmpegUpdate% --mplayer=%mplayer% --mpv=%mpv% --mkv=%mkv% --nonfree=%binary%  --stripping=%stripFile% --packing=%packFile%
 
 exit

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -61,6 +61,7 @@ if exist %ini% GOTO checkINI
     set x264INI=0
     set x265INI=0
     set other265INI=0
+    set mediainfoINI=0
     set ffmpegINI=0
     set ffmpegUpdateINI=0
     set mp4boxINI=0
@@ -88,6 +89,8 @@ findstr /i "x264" %ini% > nul
 findstr /i "x265" %ini% > nul
     if ERRORLEVEL 1 del %ini% && GOTO selectmsys2Arch
 findstr /i "other265" %ini% > nul
+    if ERRORLEVEL 1 del %ini% && GOTO selectmsys2Arch
+findstr /i "mediainfo" %ini% > nul
     if ERRORLEVEL 1 del %ini% && GOTO selectmsys2Arch
 findstr /i "ffmpegB" %ini% > nul
     if ERRORLEVEL 1 del %ini% && GOTO selectmsys2Arch
@@ -118,6 +121,7 @@ for /F "tokens=2 delims==" %%f in ('findstr /i "ffmbc" %ini%') do set ffmbcINI=%
 for /F "tokens=2 delims==" %%f in ('findstr /i "x264" %ini%') do set x264INI=%%f
 for /F "tokens=2 delims==" %%f in ('findstr /i "x265" %ini%') do set x265INI=%%f
 for /F "tokens=2 delims==" %%f in ('findstr /i "other265" %ini%') do set other265INI=%%f
+for /F "tokens=2 delims==" %%f in ('findstr /i "mediainfo" %ini%') do set mediainfoINI=%%f
 for /F "tokens=2 delims==" %%f in ('findstr /i "ffmpegB" %ini%') do set ffmpegINI=%%f
 for /F "tokens=2 delims==" %%c in ('findstr /i "ffmpegUpdate" %ini%') do set ffmpegUpdateINI=%%c
 for /F "tokens=2 delims==" %%d in ('findstr /i "mp4box" %ini%') do set mp4boxINI=%%d
@@ -307,6 +311,33 @@ if %buildother265%==2 (
     )
 if %buildother265% GTR 2 GOTO other265
 if %writeother265%==yes echo.other265=^%buildother265%>>%ini%
+
+:mediainfo
+set "writemediainfo=no"
+if %mediainfoINI%==0 (
+    echo -------------------------------------------------------------------------------
+    echo -------------------------------------------------------------------------------
+    echo.
+    echo. Build mediainfo binaries [Multimedia file information tool]?
+    echo. 1 = Yes
+    echo. 2 = No
+    echo.
+    echo -------------------------------------------------------------------------------
+    echo -------------------------------------------------------------------------------
+    set /P buildmediainfo="Build mediainfo: "
+    set "writemediainfo=yes"
+    ) else (
+        set buildmediainfo=%mediainfoINI%
+        )
+
+if %buildmediainfo%==1 (
+    set "mediainfo=y"
+    )
+if %buildmediainfo%==2 (
+    set "mediainfo=n"
+    )
+if %buildmediainfo% GTR 2 GOTO mediainfo
+if %writemediainfo%==yes echo.mediainfo=^%buildmediainfo%>>%ini%
 
 :ffmpeg
 set "writeFF=no"
@@ -1189,6 +1220,6 @@ IF ERRORLEVEL == 1 (
     pause
   )
 
-start %instdir%\%msys2%\usr\bin\mintty.exe -i /msys2.ico /usr/bin/bash --login %instdir%\media-suite_compile.sh --cpuCount=%cpuCount% --build32=%build32% --build64=%build64% --deleteSource=%deleteSource% --mp4box=%mp4box% --ffmbc=%ffmbc% --x264=%x264% --x265=%x265% --other265=%other265% --ffmpeg=%ffmpeg% --ffmpegUpdate=%ffmpegUpdate% --mplayer=%mplayer% --mpv=%mpv% --mkv=%mkv% --nonfree=%binary%  --stripping=%stripFile% --packing=%packFile%
+start %instdir%\%msys2%\usr\bin\mintty.exe -i /msys2.ico /usr/bin/bash --login %instdir%\media-suite_compile.sh --cpuCount=%cpuCount% --build32=%build32% --build64=%build64% --deleteSource=%deleteSource% --mp4box=%mp4box% --ffmbc=%ffmbc% --x264=%x264% --x265=%x265% --other265=%other265% --mediainfo=%mediainfo% --ffmpeg=%ffmpeg% --ffmpegUpdate=%ffmpegUpdate% --mplayer=%mplayer% --mpv=%mpv% --mkv=%mkv% --nonfree=%binary%  --stripping=%stripFile% --packing=%packFile%
 
 exit

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -279,6 +279,7 @@ if %x264INI%==0 (
     echo. Build x264 [H.264 encoder] binary?
     echo. 1 = Yes [static]
     echo. 2 = Build library only
+    echo. 3 = No
     echo.
     echo -------------------------------------------------------------------------------
     echo -------------------------------------------------------------------------------
@@ -292,9 +293,12 @@ if %buildx264%==1 (
     set "x264=y"
     )
 if %buildx264%==2 (
+    set "x264=l"
+    )
+if %buildx264%==3 (
     set "x264=n"
     )
-if %buildx264% GTR 2 GOTO x264
+if %buildx264% GTR 3 GOTO x264
 if %writex264%==yes echo.x264=^%buildx264%>>%ini%
 
 :x265

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -62,6 +62,7 @@ if exist %ini% GOTO checkINI
     set x265INI=0
     set other265INI=0
     set mediainfoINI=0
+    set soxINI=0
     set ffmpegINI=0
     set ffmpegUpdateINI=0
     set mp4boxINI=0
@@ -91,6 +92,8 @@ findstr /i "x265" %ini% > nul
 findstr /i "other265" %ini% > nul
     if ERRORLEVEL 1 del %ini% && GOTO selectmsys2Arch
 findstr /i "mediainfo" %ini% > nul
+    if ERRORLEVEL 1 del %ini% && GOTO selectmsys2Arch
+findstr /i "soxB" %ini% > nul
     if ERRORLEVEL 1 del %ini% && GOTO selectmsys2Arch
 findstr /i "ffmpegB" %ini% > nul
     if ERRORLEVEL 1 del %ini% && GOTO selectmsys2Arch
@@ -122,6 +125,7 @@ for /F "tokens=2 delims==" %%f in ('findstr /i "x264" %ini%') do set x264INI=%%f
 for /F "tokens=2 delims==" %%f in ('findstr /i "x265" %ini%') do set x265INI=%%f
 for /F "tokens=2 delims==" %%f in ('findstr /i "other265" %ini%') do set other265INI=%%f
 for /F "tokens=2 delims==" %%f in ('findstr /i "mediainfo" %ini%') do set mediainfoINI=%%f
+for /F "tokens=2 delims==" %%f in ('findstr /i "soxB" %ini%') do set soxINI=%%f
 for /F "tokens=2 delims==" %%f in ('findstr /i "ffmpegB" %ini%') do set ffmpegINI=%%f
 for /F "tokens=2 delims==" %%c in ('findstr /i "ffmpegUpdate" %ini%') do set ffmpegUpdateINI=%%c
 for /F "tokens=2 delims==" %%d in ('findstr /i "mp4box" %ini%') do set mp4boxINI=%%d
@@ -338,6 +342,33 @@ if %buildmediainfo%==2 (
     )
 if %buildmediainfo% GTR 2 GOTO mediainfo
 if %writemediainfo%==yes echo.mediainfo=^%buildmediainfo%>>%ini%
+
+:sox
+set "writesox=no"
+if %soxINI%==0 (
+    echo -------------------------------------------------------------------------------
+    echo -------------------------------------------------------------------------------
+    echo.
+    echo. Build sox binaries [Sound processing tool]?
+    echo. 1 = Yes
+    echo. 2 = No
+    echo.
+    echo -------------------------------------------------------------------------------
+    echo -------------------------------------------------------------------------------
+    set /P buildsox="Build sox: "
+    set "writesox=yes"
+    ) else (
+        set buildsox=%soxINI%
+        )
+
+if %buildsox%==1 (
+    set "sox=y"
+    )
+if %buildsox%==2 (
+    set "sox=n"
+    )
+if %buildsox% GTR 2 GOTO sox
+if %writesox%==yes echo.soxB=^%buildsox%>>%ini%
 
 :ffmpeg
 set "writeFF=no"
@@ -1220,6 +1251,6 @@ IF ERRORLEVEL == 1 (
     pause
   )
 
-start %instdir%\%msys2%\usr\bin\mintty.exe -i /msys2.ico /usr/bin/bash --login %instdir%\media-suite_compile.sh --cpuCount=%cpuCount% --build32=%build32% --build64=%build64% --deleteSource=%deleteSource% --mp4box=%mp4box% --ffmbc=%ffmbc% --x264=%x264% --x265=%x265% --other265=%other265% --mediainfo=%mediainfo% --ffmpeg=%ffmpeg% --ffmpegUpdate=%ffmpegUpdate% --mplayer=%mplayer% --mpv=%mpv% --mkv=%mkv% --nonfree=%binary%  --stripping=%stripFile% --packing=%packFile%
+start %instdir%\%msys2%\usr\bin\mintty.exe -i /msys2.ico /usr/bin/bash --login %instdir%\media-suite_compile.sh --cpuCount=%cpuCount% --build32=%build32% --build64=%build64% --deleteSource=%deleteSource% --mp4box=%mp4box% --ffmbc=%ffmbc% --x264=%x264% --x265=%x265% --other265=%other265% --mediainfo=%mediainfo% --sox=%sox% --ffmpeg=%ffmpeg% --ffmpegUpdate=%ffmpegUpdate% --mplayer=%mplayer% --mpv=%mpv% --mkv=%mkv% --nonfree=%binary%  --stripping=%stripFile% --packing=%packFile%
 
 exit

--- a/media-suite_compile.sh
+++ b/media-suite_compile.sh
@@ -747,42 +747,6 @@ if [[ $compile == "no" ]]; then # is deactivated for the moment
 #   echo -------------------------------------------------
 fi
 
-if [[ $mpv == "y" && ! $ffmpeg == "s" ]]; then
-
-    cd $LOCALBUILDDIR
-
-    do_git "git://midipix.org/waio" waio shallow master lib/libwaio.a
-
-    if [[ $compile == "true" ]]; then
-        if [[ $bits = "32bit" ]]; then
-            if [[ -f lib32/libwaio.a ]]; then
-                ./build-mingw-nt32 clean
-                rm -rf $LOCALDESTDIR/include/waio
-                rm -f $LOCALDESTDIR/lib/libwaio.a
-            fi
-
-            build-mingw-nt32 AR=i686-w64-mingw32-gcc-ar LD=ld STRIP=strip lib-static
-
-            cp -r include/waio  $LOCALDESTDIR/include/
-            cp -r lib32/libwaio.a $LOCALDESTDIR/lib/
-        else
-            if [[ -f lib64/libwaio.a ]]; then
-                ./build-mingw-nt64 clean
-                rm -rf $LOCALDESTDIR/include/waio
-                rm -f $LOCALDESTDIR/lib/libwaio.a
-            fi
-
-            build-mingw-nt64 AR=x86_64-w64-mingw32-gcc-ar LD=ld STRIP=strip lib-static
-
-            cp -r include/waio  $LOCALDESTDIR/include/
-            cp -r lib64/libwaio.a $LOCALDESTDIR/lib/
-        fi
-
-        do_checkIfExist waio-git libwaio.a
-        compile="false"
-    fi
-fi
-
 if [[ $mkv = "y" ]]; then
 
     cd $LOCALBUILDDIR
@@ -2260,7 +2224,40 @@ fi
 
 cd $LOCALBUILDDIR
 
-if [[ $mpv = "y" ]]; then
+if [[ $mpv = "y" && $ffmpeg = "y" ]]; then
+
+    do_git "git://midipix.org/waio" waio shallow master lib/libwaio.a
+
+    if [[ $compile == "true" ]]; then
+        if [[ $bits = "32bit" ]]; then
+            if [[ -f lib32/libwaio.a ]]; then
+                ./build-mingw-nt32 clean
+                rm -rf $LOCALDESTDIR/include/waio
+                rm -f $LOCALDESTDIR/lib/libwaio.a
+            fi
+
+            build-mingw-nt32 AR=i686-w64-mingw32-gcc-ar LD=ld STRIP=strip lib-static
+
+            cp -r include/waio  $LOCALDESTDIR/include/
+            cp -r lib32/libwaio.a $LOCALDESTDIR/lib/
+        else
+            if [[ -f lib64/libwaio.a ]]; then
+                ./build-mingw-nt64 clean
+                rm -rf $LOCALDESTDIR/include/waio
+                rm -f $LOCALDESTDIR/lib/libwaio.a
+            fi
+
+            build-mingw-nt64 AR=x86_64-w64-mingw32-gcc-ar LD=ld STRIP=strip lib-static
+
+            cp -r include/waio  $LOCALDESTDIR/include/
+            cp -r lib64/libwaio.a $LOCALDESTDIR/lib/
+        fi
+
+        do_checkIfExist waio-git libwaio.a
+        compile="false"
+    fi
+
+    cd $LOCALBUILDDIR
 
     do_git "http://luajit.org/git/luajit-2.0.git" luajit noDepth
 
@@ -2303,7 +2300,7 @@ if [[ $mpv = "y" ]]; then
 
     do_git "https://github.com/mpv-player/mpv.git" mpv shallow master bin-video/mpv.exe
 
-    if [[ $compile == "true" ]] && [[ ! $ffmpeg == "s" ]] || [[ $newFfmpeg == "yes" ]]; then
+    if [[ $compile == "true" ]] || [[ $newFfmpeg == "yes" ]]; then
         if [ ! -f waf ]; then
             python2 ./bootstrap.py
         else

--- a/media-suite_compile.sh
+++ b/media-suite_compile.sh
@@ -14,6 +14,7 @@ while true; do
 --x264=* ) x264="${1#*=}"; shift ;;
 --x265=* ) x265="${1#*=}"; shift ;;
 --other265=* ) other265="${1#*=}"; shift ;;
+--mediainfo=* ) mediainfo="${1#*=}"; shift ;;
 --ffmpeg=* ) ffmpeg="${1#*=}"; shift ;;
 --ffmpegUpdate=* ) ffmpegUpdate="${1#*=}"; shift ;;
 --mplayer=* ) mplayer="${1#*=}"; shift ;;
@@ -1372,12 +1373,13 @@ if [ -f "$LOCALDESTDIR/lib/libxavs.a" ]; then
         do_checkIfExist xavs libxavs.a
 fi
 
-cd $LOCALBUILDDIR
+if [ $mediainfo = "y" ]; then
+    cd $LOCALBUILDDIR
 
-if [ -f "$LOCALDESTDIR/bin-video/mediainfo.exe" ]; then
-    echo -------------------------------------------------
-    echo "MediaInfo_CLI is already compiled"
-    echo -------------------------------------------------
+    if [ -f "$LOCALDESTDIR/bin-video/mediainfo.exe" ]; then
+        echo -------------------------------------------------
+        echo "MediaInfo_CLI is already compiled"
+        echo -------------------------------------------------
     else
         echo -ne "\033]0;compile MediaInfo_CLI $bits\007"
 
@@ -1443,6 +1445,7 @@ if [ -f "$LOCALDESTDIR/bin-video/mediainfo.exe" ]; then
         cp mediainfo.exe $LOCALDESTDIR/bin-video/mediainfo.exe
 
         do_checkIfExist mediainfo bin-video/mediainfo.exe
+    fi
 fi
 
 cd $LOCALBUILDDIR

--- a/media-suite_compile.sh
+++ b/media-suite_compile.sh
@@ -877,7 +877,7 @@ fi
 
 cd $LOCALBUILDDIR
 
-if [[ `PKG_CONFIG_PATH="$LOCALDESTDIR/lib/pkgconfig" pkg-config --modversion flac` = "1.3.1" ]]; then
+if [[ `pkg-config --modversion flac` = "1.3.1" ]]; then
     echo -------------------------------------------------
     echo "flac-1.3.1 is already compiled"
     echo -------------------------------------------------

--- a/media-suite_compile.sh
+++ b/media-suite_compile.sh
@@ -1746,64 +1746,66 @@ fi
 
 cd $LOCALBUILDDIR
 
-do_git "git://git.videolan.org/x264.git" x264 noDepth
+if [[ ! $x264 = "n" ]]; then
+    do_git "git://git.videolan.org/x264.git" x264 noDepth
 
-if [[ $compile = "true" ]]; then
-    if [[ $x264 = "y" ]]; then
-        cd $LOCALBUILDDIR
+    if [[ $compile = "true" ]]; then
+        if [[ $x264 = "y" ]]; then
+            cd $LOCALBUILDDIR
 
-        do_git "https://github.com/FFmpeg/FFmpeg.git" ffmpeg noDepth master bin-video/ffmpeg.exe
+            do_git "https://github.com/FFmpeg/FFmpeg.git" ffmpeg noDepth master bin-video/ffmpeg.exe
 
-        if [ -f "$LOCALDESTDIR/lib/libavcodec.a" ]; then
-            rm -rf $LOCALDESTDIR/include/libavutil
-            rm -rf $LOCALDESTDIR/include/libavcodec
-            rm -rf $LOCALDESTDIR/include/libpostproc
-            rm -rf $LOCALDESTDIR/include/libswresample
-            rm -rf $LOCALDESTDIR/include/libswscale
-            rm -rf $LOCALDESTDIR/include/libavdevice
-            rm -rf $LOCALDESTDIR/include/libavfilter
-            rm -rf $LOCALDESTDIR/include/libavformat
-            rm -f $LOCALDESTDIR/lib/libavutil.a
-            rm -f $LOCALDESTDIR/lib/libswresample.a
-            rm -f $LOCALDESTDIR/lib/libswscale.a
-            rm -f $LOCALDESTDIR/lib/libavcodec.a
-            rm -f $LOCALDESTDIR/lib/libavdevice.a
-            rm -f $LOCALDESTDIR/lib/libavfilter.a
-            rm -f $LOCALDESTDIR/lib/libavformat.a
-            rm -f $LOCALDESTDIR/lib/libpostproc.a
-            rm -f $LOCALDESTDIR/lib/pkgconfig/libavcodec.pc
-            rm -f $LOCALDESTDIR/lib/pkgconfig/libavutil.pc
-            rm -f $LOCALDESTDIR/lib/pkgconfig/libpostproc.pc
-            rm -f $LOCALDESTDIR/lib/pkgconfig/libswresample.pc
-            rm -f $LOCALDESTDIR/lib/pkgconfig/libswscale.pc
-            rm -f $LOCALDESTDIR/lib/pkgconfig/libavdevice.pc
-            rm -f $LOCALDESTDIR/lib/pkgconfig/libavfilter.pc
-            rm -f $LOCALDESTDIR/lib/pkgconfig/libavformat.pc
+            if [ -f "$LOCALDESTDIR/lib/libavcodec.a" ]; then
+                rm -rf $LOCALDESTDIR/include/libavutil
+                rm -rf $LOCALDESTDIR/include/libavcodec
+                rm -rf $LOCALDESTDIR/include/libpostproc
+                rm -rf $LOCALDESTDIR/include/libswresample
+                rm -rf $LOCALDESTDIR/include/libswscale
+                rm -rf $LOCALDESTDIR/include/libavdevice
+                rm -rf $LOCALDESTDIR/include/libavfilter
+                rm -rf $LOCALDESTDIR/include/libavformat
+                rm -f $LOCALDESTDIR/lib/libavutil.a
+                rm -f $LOCALDESTDIR/lib/libswresample.a
+                rm -f $LOCALDESTDIR/lib/libswscale.a
+                rm -f $LOCALDESTDIR/lib/libavcodec.a
+                rm -f $LOCALDESTDIR/lib/libavdevice.a
+                rm -f $LOCALDESTDIR/lib/libavfilter.a
+                rm -f $LOCALDESTDIR/lib/libavformat.a
+                rm -f $LOCALDESTDIR/lib/libpostproc.a
+                rm -f $LOCALDESTDIR/lib/pkgconfig/libavcodec.pc
+                rm -f $LOCALDESTDIR/lib/pkgconfig/libavutil.pc
+                rm -f $LOCALDESTDIR/lib/pkgconfig/libpostproc.pc
+                rm -f $LOCALDESTDIR/lib/pkgconfig/libswresample.pc
+                rm -f $LOCALDESTDIR/lib/pkgconfig/libswscale.pc
+                rm -f $LOCALDESTDIR/lib/pkgconfig/libavdevice.pc
+                rm -f $LOCALDESTDIR/lib/pkgconfig/libavfilter.pc
+                rm -f $LOCALDESTDIR/lib/pkgconfig/libavformat.pc
+            fi
+
+            if [ -f "config.mak" ]; then
+                make distclean
+            fi
+
+            if [[ $bits = "32bit" ]]; then
+                arch='x86'
+            else
+                arch='x86_64'
+            fi
+
+            ./configure --arch=$arch --target-os=mingw32 --prefix=$LOCALDESTDIR --disable-debug --disable-shared --disable-doc --enable-runtime-cpudetect --disable-programs --disable-devices --disable-filters --disable-encoders --disable-muxers
+
+            make -j $cpuCount
+            make install
+
+            sed -i "s/ -lp11-kit//g" $LOCALDESTDIR/lib/pkgconfig/libavcodec.pc
+            sed -i "s/ -lp11-kit//g" $LOCALDESTDIR/lib/pkgconfig/libavdevice.pc
+            sed -i "s/ -lp11-kit//g" $LOCALDESTDIR/lib/pkgconfig/libavfilter.pc
+            sed -i "s/ -lp11-kit//g" $LOCALDESTDIR/lib/pkgconfig/libavformat.pc
+
+            do_checkIfExist ffmpeg-git libavcodec.a
+
+            cd $LOCALBUILDDIR/x264-git
         fi
-
-        if [ -f "config.mak" ]; then
-            make distclean
-        fi
-
-        if [[ $bits = "32bit" ]]; then
-            arch='x86'
-        else
-            arch='x86_64'
-        fi
-
-        ./configure --arch=$arch --target-os=mingw32 --prefix=$LOCALDESTDIR --disable-debug --disable-shared --disable-doc --enable-runtime-cpudetect --disable-programs --disable-devices --disable-filters --disable-encoders --disable-muxers
-
-        make -j $cpuCount
-        make install
-
-        sed -i "s/ -lp11-kit//g" $LOCALDESTDIR/lib/pkgconfig/libavcodec.pc
-        sed -i "s/ -lp11-kit//g" $LOCALDESTDIR/lib/pkgconfig/libavdevice.pc
-        sed -i "s/ -lp11-kit//g" $LOCALDESTDIR/lib/pkgconfig/libavfilter.pc
-        sed -i "s/ -lp11-kit//g" $LOCALDESTDIR/lib/pkgconfig/libavformat.pc
-
-        do_checkIfExist ffmpeg-git libavcodec.a
-
-        cd $LOCALBUILDDIR/x264-git
 
         echo -ne "\033]0;compile x264-git $bits\007"
 
@@ -1816,32 +1818,17 @@ if [[ $compile = "true" ]]; then
             make distclean
         fi
 
-        ./configure --host=$targetHost --prefix=$LOCALDESTDIR --bindir=$LOCALDESTDIR/bin-video --enable-static --bit-depth=10 --enable-win32thread
-        make -j $cpuCount
+        if [[ $x264 = "y" ]]; then
+            ./configure --host=$targetHost --prefix=$LOCALDESTDIR --bindir=$LOCALDESTDIR/bin-video --enable-static --bit-depth=10 --enable-win32thread
+            make -j $cpuCount
 
-        cp x264.exe $LOCALDESTDIR/bin-video/x264-10bit.exe
-        make clean
+            cp x264.exe $LOCALDESTDIR/bin-video/x264-10bit.exe
+            make clean
 
-        ./configure --host=$targetHost --prefix=$LOCALDESTDIR --bindir=$LOCALDESTDIR/bin-video --enable-static --enable-win32thread
-
-        make -j $cpuCount
-        make install
-
-        do_checkIfExist x264-git libx264.a
-        buildFFmpeg="true"
-    else
-        echo -ne "\033]0;compile libx264-git $bits\007"
-
-        if [ -f "$LOCALDESTDIR/lib/libx264.a" ]; then
-            rm -f $LOCALDESTDIR/include/x264.h $LOCALDESTDIR/include/x264_config.h $LOCALDESTDIR/lib/libx264.a
-            rm -f $LOCALDESTDIR/lib/pkgconfig/x264.pc
+            ./configure --host=$targetHost --prefix=$LOCALDESTDIR --bindir=$LOCALDESTDIR/bin-video --enable-static --enable-win32thread
+        else
+            ./configure --host=$targetHost --prefix=$LOCALDESTDIR --enable-static --enable-win32thread --disable-interlaced --disable-swscale --disable-lavf --disable-ffms --disable-gpac --disable-lsmash --bit-depth=8 --disable-cli
         fi
-
-        if [ -f "libx264.a" ]; then
-            make distclean
-        fi
-
-        ./configure --host=$targetHost --prefix=$LOCALDESTDIR --enable-static --enable-win32thread --disable-interlaced --disable-swscale --disable-lavf --disable-ffms --disable-gpac --disable-lsmash --bit-depth=8 --disable-cli
 
         make -j $cpuCount
         make install
@@ -1849,6 +1836,7 @@ if [[ $compile = "true" ]]; then
         do_checkIfExist x264-git libx264.a
         buildFFmpeg="true"
     fi
+    builtx264="--enable-libx264"
 fi
 
 cd $LOCALBUILDDIR
@@ -1919,8 +1907,8 @@ if [[ $ffmbc = "y" ]]; then
             if [ -f "config.log" ]; then
                 make distclean
             fi
-        
-            ./configure --arch=$arch --target-os=mingw32 --prefix=$LOCALDESTDIR --bindir=$LOCALDESTDIR/bin-video --disable-debug --disable-shared --disable-doc --disable-avdevice --disable-dxva2 --disable-ffprobe --disable-w32threads --enable-gpl --enable-runtime-cpudetect --enable-bzlib --enable-zlib --enable-librtmp --enable-avisynth --enable-frei0r --enable-libopenjpeg --enable-libass --enable-libmp3lame --enable-libschroedinger --enable-libspeex --enable-libtheora --enable-libvorbis $builtvpx --enable-libxavs --enable-libx264 --enable-libxvid $extras --extra-cflags='-DPTW32_STATIC_LIB' --extra-libs='-ldl'
+
+            ./configure --arch=$arch --target-os=mingw32 --prefix=$LOCALDESTDIR --bindir=$LOCALDESTDIR/bin-video --disable-debug --disable-shared --disable-doc --disable-avdevice --disable-dxva2 --disable-ffprobe --disable-w32threads --enable-gpl --enable-runtime-cpudetect --enable-bzlib --enable-zlib --enable-librtmp --enable-avisynth --enable-frei0r --enable-libopenjpeg --enable-libass --enable-libmp3lame --enable-libschroedinger --enable-libspeex --enable-libtheora --enable-libvorbis $builtvpx --enable-libxavs $builtx264 --enable-libxvid $extras --extra-cflags='-DPTW32_STATIC_LIB' --extra-libs='-ldl'
 
             make SRC_DIR=. -j $cpuCount
             make SRC_DIR=. install-progs
@@ -1996,7 +1984,7 @@ if [[ $ffmpeg = "y" ]] || [[ $ffmpeg = "s" ]]; then
             --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libvo-amrwbenc --enable-libschroedinger \
             --enable-libsoxr --enable-libtwolame --enable-libspeex --enable-libtheora --enable-libvorbis \
             --enable-libvo-aacenc --enable-libopus --enable-libvidstab $builtvpx --enable-libwavpack \
-            --enable-libxavs --enable-libx264 --enable-libx265 --enable-libxvid --enable-libzvbi \
+            --enable-libxavs $builtx264 --enable-libx265 --enable-libxvid --enable-libzvbi \
             --enable-libdcadec --enable-libbs2b $extras \
             --extra-cflags='-DPTW32_STATIC_LIB -DLIBTWOLAME_STATIC -DCACA_STATIC -DMODPLUG_STATIC' \
             --extra-libs='-lxml2 -llzma -lstdc++ -lpng -lm -lpthread -lwsock32 -lhogweed -lnettle -lgmp -ltasn1 -lws2_32 -lwinmm -lgdi32 -lcrypt32 -lintl -lz -liconv -lole32 -loleaut32' \
@@ -2013,7 +2001,7 @@ if [[ $ffmpeg = "y" ]] || [[ $ffmpeg = "s" ]]; then
             --enable-libvo-amrwbenc --enable-libschroedinger --enable-libsoxr --enable-libtwolame \
             --enable-libspeex --enable-libtheora --enable-libutvideo --enable-libvorbis --enable-libvo-aacenc \
             --enable-libopus --enable-libvidstab $builtvpx --enable-libwavpack --enable-libxavs \
-            --enable-libx264 --enable-libx265 --enable-libxvid --enable-libzvbi \
+            $builtx264 --enable-libx265 --enable-libxvid --enable-libzvbi \
             --enable-libgme --enable-libdcadec --enable-libbs2b $extras \
             --extra-cflags='-DPTW32_STATIC_LIB -DLIBTWOLAME_STATIC -DCACA_STATIC -DMODPLUG_STATIC' \
             --extra-libs='-lxml2 -llzma -lstdc++ -lpng -lm -lpthread -lwsock32 -lhogweed -lnettle -lgmp -ltasn1 -lws2_32 -lwinmm -lgdi32 -lcrypt32 -lintl -lz -liconv -lole32 -loleaut32' \


### PR DESCRIPTION
These are the options that should not be optional to choose since they all take a long time to build and add a bit of size to ffmpeg (vpx, x264 and x265).

People might also not want mediainfo and sox. SoxR can still be built without Sox since it's just its resampling library.

The last two commits make x264 and x265 actually optional, since we now only choose between building binaries and libs or libs only.

The rest of the options will be behind one last option, so we can merge this now and save the rest for a later bunch of commits in a week or more so we don't delete people's INIs too much.