### PR TITLE
Remove redundant extra-libs from ffmpeg

### DIFF
--- a/media-suite_compile.sh
+++ b/media-suite_compile.sh
@@ -1458,8 +1458,11 @@ if [ -f "$LOCALDESTDIR/lib/libxavs.a" ]; then
 
         ./configure --host=$targetHost --prefix=$LOCALDESTDIR --bindir=$LOCALDESTDIR/bin-video
 
-        make -j $cpuCount
-        make install
+        make -j $cpuCount libxavs.a
+
+        install -m 644 xavs.h $LOCALDESTDIR/include
+        install -m 644 libxavs.a $LOCALDESTDIR/lib
+        install -m 644 xavs.pc $LOCALDESTDIR/lib/pkgconfig
 
         do_checkIfExist xavs libxavs.a
 fi

--- a/media-suite_compile.sh
+++ b/media-suite_compile.sh
@@ -1575,16 +1575,18 @@ do_pkgConfig "caca = 0.99.beta19"
 if [[ $compile = "true" ]]; then
     do_wget_tar "https://fossies.org/linux/privat/libcaca-0.99.beta19.tar.gz"
 
-    cd caca
-
-    if [[ -f ".libs/libcaca.a" ]]; then
+    if [[ -f "caca/.libs/libcaca.a" ]]; then
         make distclean
+    else
+        sed -i -e 's/src //g' -e 's/examples //g' -e 's/doc //g' Makefile.am
+        autoreconf -fiv
     fi
     if [[ -f "$LOCALDESTDIR/include/caca.h" ]]; then
         rm -rf $LOCALDESTDIR/include/caca* $LOCALDESTDIR/bin-video/caca*
         rm -rf $LOCALDESTDIR/lib/libcaca.{l,}a $LOCALDESTDIR/lib/pkgconfig/caca.pc
     fi
 
+    cd caca
     sed -i "s/#if defined _WIN32 && defined __GNUC__ && __GNUC__ >= 3/#if defined __MINGW__/g" string.c
     sed -i "s/#if defined(HAVE_VSNPRINTF_S)//g" string.c
     sed -i "s/vsnprintf_s(buf, bufsize, _TRUNCATE, format, args);//g" string.c
@@ -1595,9 +1597,9 @@ if [[ $compile = "true" ]]; then
     sed -i "s/__declspec(dllimport)//g" *.h
     cd ..
 
-    ./configure --build=$targetBuild --host=$targetHost --prefix=$LOCALDESTDIR --bindir=$LOCALDESTDIR/bin-video --disable-shared --disable-cxx --disable-csharp --disable-ncurses --disable-java --disable-python --disable-ruby --disable-imlib2 --disable-doc
+    ./configure --build=$targetBuild --prefix=$LOCALDESTDIR --bindir=$LOCALDESTDIR/bin-global --disable-shared --disable-cxx --disable-csharp --disable-ncurses --disable-java --disable-python --disable-ruby --disable-imlib2 --disable-doc
 
-    sed -i 's/ln -sf/$(LN_S)/' "caca/Makefile" "cxx/Makefile" "doc/Makefile"
+    sed -i 's/ln -sf/$(LN_S)/' "doc/Makefile"
 
     make -j $cpuCount
     make install

--- a/media-suite_compile.sh
+++ b/media-suite_compile.sh
@@ -1994,33 +1994,33 @@ if [[ $ffmpeg = "y" ]] || [[ $ffmpeg = "s" ]]; then
             fi
             CPPFLAGS='-DFRIBIDI_ENTRY=""' LDFLAGS="$LDFLAGS -static-libgcc" ./configure \
             --arch=$arch --target-os=mingw32 --prefix=$LOCALDESTDIR/bin-video/ffmpegSHARED \
-            --disable-debug --disable-static --disable-doc --disable-w32threads --enable-shared \
-            --enable-gpl --enable-version3 --enable-runtime-cpudetect --enable-avfilter --enable-bzlib \
-            --enable-zlib --enable-librtmp --enable-gnutls --enable-avisynth --enable-frei0r --enable-filter=frei0r \
+            --disable-debug --disable-doc --disable-w32threads --enable-gpl --enable-version3 \
+            --disable-static --enable-shared \
+            --enable-librtmp --enable-gnutls --enable-avisynth --enable-frei0r --enable-filter=frei0r \
             --enable-libbluray --enable-libcaca --enable-libopenjpeg --enable-fontconfig --enable-libfreetype \
             --enable-libass --enable-libgsm --enable-libilbc --enable-libmodplug --enable-libmp3lame \
             --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libvo-amrwbenc --enable-libschroedinger \
             --enable-libsoxr --enable-libtwolame --enable-libspeex --enable-libtheora --enable-libvorbis \
-            --enable-libvo-aacenc --enable-libopus --enable-libvidstab $builtvpx \
-            --enable-libxavs $builtx264 $builtx265 --enable-libxvid --enable-libzvbi \
-            --enable-libdcadec --enable-libbs2b $extras \
+            --enable-libvo-aacenc --enable-libopus --enable-libvidstab --enable-libxavs \
+            --enable-libxvid --enable-libzvbi --enable-libdcadec --enable-libbs2b \
+            $builtvpx $builtx264 $builtx265 $extras \
             --extra-cflags='-DPTW32_STATIC_LIB -DLIBTWOLAME_STATIC -DCACA_STATIC -DMODPLUG_STATIC' \
             --extra-libs='-lpng -lpthread -lwsock32' \
             --extra-ldflags='-mconsole -Wl,--allow-multiple-definition'
         else
             CPPFLAGS='-DFRIBIDI_ENTRY=""' ./configure \
             --arch=$arch --target-os=mingw32 --prefix=$LOCALDESTDIR --bindir=$LOCALDESTDIR/bin-video \
-            --disable-debug --disable-shared --disable-doc --disable-w32threads --enable-gpl \
-            --enable-version3 --enable-runtime-cpudetect --enable-avfilter --enable-bzlib --enable-zlib \
-            --enable-decklink --enable-librtmp --enable-gnutls --enable-avisynth --enable-frei0r \
-            --enable-filter=frei0r --enable-libbluray --enable-libcaca --enable-libopenjpeg \
-            --enable-fontconfig --enable-libfreetype --enable-libass --enable-libgsm --enable-libilbc \
-            --enable-libmodplug --enable-libmp3lame --enable-libopencore-amrnb --enable-libopencore-amrwb \
-            --enable-libvo-amrwbenc --enable-libschroedinger --enable-libsoxr --enable-libtwolame \
-            --enable-libspeex --enable-libtheora --enable-libutvideo --enable-libvorbis --enable-libvo-aacenc \
-            --enable-libopus --enable-libvidstab $builtvpx --enable-libxavs \
-            $builtx264 $builtx265 --enable-libxvid --enable-libzvbi \
-            --enable-libgme --enable-libdcadec --enable-libbs2b $extras \
+            --disable-debug --disable-doc --disable-w32threads --enable-gpl --enable-version3 \
+            --enable-static --disable-shared \
+            --enable-decklink --enable-libutvideo --enable-libgme \
+            --enable-librtmp --enable-gnutls --enable-avisynth --enable-frei0r --enable-filter=frei0r \
+            --enable-libbluray --enable-libcaca --enable-libopenjpeg --enable-fontconfig --enable-libfreetype \
+            --enable-libass --enable-libgsm --enable-libilbc --enable-libmodplug --enable-libmp3lame \
+            --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libvo-amrwbenc --enable-libschroedinger \
+            --enable-libsoxr --enable-libtwolame --enable-libspeex --enable-libtheora --enable-libvorbis \
+            --enable-libvo-aacenc --enable-libopus --enable-libvidstab --enable-libxavs \
+            --enable-libxvid --enable-libzvbi --enable-libdcadec --enable-libbs2b \
+            $builtvpx $builtx264 $builtx265 $extras \
             --extra-cflags='-DPTW32_STATIC_LIB -DLIBTWOLAME_STATIC -DCACA_STATIC -DMODPLUG_STATIC' \
             --extra-libs='-lpng -lpthread -lwsock32' \
             --extra-ldflags='-mconsole -Wl,--allow-multiple-definition'

--- a/media-suite_compile.sh
+++ b/media-suite_compile.sh
@@ -1139,7 +1139,8 @@ if [[ $compile = "true" ]]; then
             rm -rf $LOCALDESTDIR/lib/libbs2b.{l,}a $LOCALDESTDIR/lib/pkgconfig/libbs2b.pc
         fi
 
-        ./configure --build=$targetBuild --host=$targetHost --prefix=$LOCALDESTDIR --bindir=$LOCALDESTDIR/bin-audio --disable-shared
+        sed -i 's/bs2bconvert$(EXEEXT) bs2bstream$(EXEEXT)//' src/Makefile.in
+        ./configure --build=$targetBuild --prefix=$LOCALDESTDIR --disable-shared
 
         make -j $cpuCount
         make install

--- a/media-suite_compile.sh
+++ b/media-suite_compile.sh
@@ -1118,7 +1118,8 @@ if [[ $compile = "true" ]]; then
             rm -rf $LOCALDESTDIR/lib/libtwolame.{l,}a $LOCALDESTDIR/lib/pkgconfig/twolame.pc
         fi
         
-        ./configure --build=$targetBuild --host=$targetHost --prefix=$LOCALDESTDIR --bindir=$LOCALDESTDIR/bin-audio --disable-shared
+        ./configure --build=$targetBuild --host=$targetHost --prefix=$LOCALDESTDIR --disable-shared
+        sed -i 's/frontend simplefrontend//' Makefile
         
         make -j $cpuCount
         make install

--- a/media-suite_compile.sh
+++ b/media-suite_compile.sh
@@ -1085,9 +1085,11 @@ if [[ $compile = "true" ]]; then
     if [[ ! -f ./configure ]]; then
         ./autogen.sh
     else
+        make distclean
+    fi
+    if [[ -f "$LOCALDESTDIR/include/sndfile.h" ]]; then
         rm -rf $LOCALDESTDIR/include/sndfile.{h,}h $LOCALDESTDIR/bin-audio/sndfile-*
         rm -rf $LOCALDESTDIR/lib/libsndfile.{l,}a $LOCALDESTDIR/lib/pkgconfig/sndfile.pc
-        make distclean
     fi
 
     ./configure --build=$targetBuild --host=$targetHost --prefix=$LOCALDESTDIR --disable-shared
@@ -1103,12 +1105,12 @@ fi
 
 cd $LOCALBUILDDIR
 
-do_pkgConfig "twolame = 0.3.13"
+do_git "https://github.com/qyot27/twolame.git" twolame shallow mingw-static
 
 if [[ $compile = "true" ]]; then
-        do_wget_tar "http://sourceforge.net/projects/twolame/files/twolame/0.3.13/twolame-0.3.13.tar.gz"
-
-        if [[ -f "libtwolame\.libs\libtwolame.a" ]]; then
+        if [[ ! -f ./configure ]]; then
+            ./autogen.sh -V
+        else
             make distclean
         fi
         if [[ -f "$LOCALDESTDIR/include/twolame.h" ]]; then
@@ -1116,12 +1118,12 @@ if [[ $compile = "true" ]]; then
             rm -rf $LOCALDESTDIR/lib/libtwolame.{l,}a $LOCALDESTDIR/lib/pkgconfig/twolame.pc
         fi
         
-        ./configure --build=$targetBuild --host=$targetHost --prefix=$LOCALDESTDIR --bindir=$LOCALDESTDIR/bin-audio --disable-shared CPPFLAGS="$CPPFLAGS -DLIBTWOLAME_STATIC"
+        ./configure --build=$targetBuild --host=$targetHost --prefix=$LOCALDESTDIR --bindir=$LOCALDESTDIR/bin-audio --disable-shared
         
         make -j $cpuCount
         make install
         
-        do_checkIfExist twolame-0.3.13 libtwolame.a
+        do_checkIfExist twolame-git libtwolame.a
 fi
 
 cd $LOCALBUILDDIR
@@ -2005,7 +2007,7 @@ if [[ $ffmpeg = "y" ]] || [[ $ffmpeg = "s" ]]; then
             --enable-libvo-aacenc --enable-libopus --enable-libvidstab --enable-libxavs \
             --enable-libxvid --enable-libzvbi --enable-libdcadec --enable-libbs2b \
             $builtvpx $builtx264 $builtx265 $extras \
-            --extra-cflags='-DPTW32_STATIC_LIB -DLIBTWOLAME_STATIC -DCACA_STATIC -DMODPLUG_STATIC' \
+            --extra-cflags='-DPTW32_STATIC_LIB -DCACA_STATIC -DMODPLUG_STATIC' \
             --extra-libs='-lpng -lpthread -lwsock32' \
             --extra-ldflags='-mconsole -Wl,--allow-multiple-definition'
         else
@@ -2022,7 +2024,7 @@ if [[ $ffmpeg = "y" ]] || [[ $ffmpeg = "s" ]]; then
             --enable-libvo-aacenc --enable-libopus --enable-libvidstab --enable-libxavs \
             --enable-libxvid --enable-libzvbi --enable-libdcadec --enable-libbs2b \
             $builtvpx $builtx264 $builtx265 $extras \
-            --extra-cflags='-DPTW32_STATIC_LIB -DLIBTWOLAME_STATIC -DCACA_STATIC -DMODPLUG_STATIC' \
+            --extra-cflags='-DPTW32_STATIC_LIB -DCACA_STATIC -DMODPLUG_STATIC' \
             --extra-libs='-lpng -lpthread -lwsock32' \
             --extra-ldflags='-mconsole -Wl,--allow-multiple-definition'
 
@@ -2031,7 +2033,7 @@ if [[ $ffmpeg = "y" ]] || [[ $ffmpeg = "s" ]]; then
 
         sed -i "s|--target-os=mingw32 --prefix=$LOCALDESTDIR --bindir=$LOCALDESTDIR/bin-video ||g" config.h
 
-        sed -i "s/ --extra-cflags='-DPTW32_STATIC_LIB -DLIBTWOLAME_STATIC -DCACA_STATIC -DMODPLUG_STATIC' --extra-libs='-lpng -lpthread -lwsock32' --extra-ldflags='-mconsole -Wl,--allow-multiple-definition'//g" config.h
+        sed -i "s/ --extra-cflags='-DPTW32_STATIC_LIB -DCACA_STATIC -DMODPLUG_STATIC' --extra-libs='-lpng -lpthread -lwsock32' --extra-ldflags='-mconsole -Wl,--allow-multiple-definition'//g" config.h
 
         make -j $cpuCount
         make install
@@ -2115,7 +2117,7 @@ if [[ $mplayer = "y" ]]; then
 
         sed -i '/#include "mp_msg.h/ a\#include <windows.h>' libmpcodecs/ad_spdif.c
 
-        CPPFLAGS='-DFRIBIDI_ENTRY=""' ./configure --prefix=$LOCALDESTDIR --bindir=$LOCALDESTDIR/bin-video --cc=gcc --extra-cflags='-DPTW32_STATIC_LIB -O3 -std=gnu99 -DLIBTWOLAME_STATIC -DMODPLUG_STATIC' --extra-libs='-lxml2 -llzma -lfreetype -lz -lbz2 -liconv -lws2_32 -lpthread -lwinpthread -lpng -lwinmm' --extra-ldflags='-Wl,--allow-multiple-definition' --enable-static --enable-runtime-cpudetection --enable-ass-internal --enable-bluray --disable-gif --enable-freetype $faac
+        CPPFLAGS='-DFRIBIDI_ENTRY=""' ./configure --prefix=$LOCALDESTDIR --bindir=$LOCALDESTDIR/bin-video --cc=gcc --extra-cflags='-DPTW32_STATIC_LIB -O3 -std=gnu99 -DMODPLUG_STATIC' --extra-libs='-lxml2 -llzma -lfreetype -lz -lbz2 -liconv -lws2_32 -lpthread -lwinpthread -lpng -lwinmm' --extra-ldflags='-Wl,--allow-multiple-definition' --enable-static --enable-runtime-cpudetection --enable-ass-internal --enable-bluray --disable-gif --enable-freetype $faac
 
         make -j $cpuCount
         make install

--- a/media-suite_compile.sh
+++ b/media-suite_compile.sh
@@ -2005,7 +2005,7 @@ if [[ $ffmpeg = "y" ]] || [[ $ffmpeg = "s" ]]; then
             --enable-libxavs $builtx264 $builtx265 --enable-libxvid --enable-libzvbi \
             --enable-libdcadec --enable-libbs2b $extras \
             --extra-cflags='-DPTW32_STATIC_LIB -DLIBTWOLAME_STATIC -DCACA_STATIC -DMODPLUG_STATIC' \
-            --extra-libs='-lxml2 -llzma -lstdc++ -lpng -lm -lpthread -lwsock32 -lhogweed -lnettle -lgmp -ltasn1 -lws2_32 -lwinmm -lgdi32 -lcrypt32 -lintl -lz -liconv -lole32 -loleaut32 -lorc-0.4' \
+            --extra-libs='-lpng -lpthread -lwsock32' \
             --extra-ldflags='-mconsole -Wl,--allow-multiple-definition'
         else
             CPPFLAGS='-DFRIBIDI_ENTRY=""' ./configure \
@@ -2022,7 +2022,7 @@ if [[ $ffmpeg = "y" ]] || [[ $ffmpeg = "s" ]]; then
             $builtx264 $builtx265 --enable-libxvid --enable-libzvbi \
             --enable-libgme --enable-libdcadec --enable-libbs2b $extras \
             --extra-cflags='-DPTW32_STATIC_LIB -DLIBTWOLAME_STATIC -DCACA_STATIC -DMODPLUG_STATIC' \
-            --extra-libs='-lxml2 -llzma -lstdc++ -lpng -lm -lpthread -lwsock32 -lhogweed -lnettle -lgmp -ltasn1 -lws2_32 -lwinmm -lgdi32 -lcrypt32 -lintl -lz -liconv -lole32 -loleaut32 -lorc-0.4' \
+            --extra-libs='-lpng -lpthread -lwsock32' \
             --extra-ldflags='-mconsole -Wl,--allow-multiple-definition'
 
             newFfmpeg="yes"
@@ -2030,16 +2030,12 @@ if [[ $ffmpeg = "y" ]] || [[ $ffmpeg = "s" ]]; then
 
         sed -i "s|--target-os=mingw32 --prefix=$LOCALDESTDIR --bindir=$LOCALDESTDIR/bin-video ||g" config.h
 
-        sed -i "s/ --extra-cflags='-DPTW32_STATIC_LIB -DLIBTWOLAME_STATIC -DCACA_STATIC -DMODPLUG_STATIC' --extra-libs='-lxml2 -llzma -lstdc++ -lpng -lm -lpthread -lwsock32 -lhogweed -lnettle -lgmp -ltasn1 -lws2_32 -lwinmm -lgdi32 -lcrypt32 -lintl -lz -liconv -lole32 -loleaut32 -lorc-0.4' --extra-ldflags='-mconsole -Wl,--allow-multiple-definition'//g" config.h
+        sed -i "s/ --extra-cflags='-DPTW32_STATIC_LIB -DLIBTWOLAME_STATIC -DCACA_STATIC -DMODPLUG_STATIC' --extra-libs='-lpng -lpthread -lwsock32' --extra-ldflags='-mconsole -Wl,--allow-multiple-definition'//g" config.h
 
         make -j $cpuCount
         make install
 
         if [[ ! $ffmpeg = "s" ]]; then
-            sed -i "s/ -lp11-kit//g" $LOCALDESTDIR/lib/pkgconfig/libavcodec.pc
-            sed -i "s/ -lp11-kit//g" $LOCALDESTDIR/lib/pkgconfig/libavdevice.pc
-            sed -i "s/ -lp11-kit//g" $LOCALDESTDIR/lib/pkgconfig/libavfilter.pc
-            sed -i "s/ -lp11-kit//g" $LOCALDESTDIR/lib/pkgconfig/libavformat.pc
             sed -i "s/Libs: -L\${libdir}  -lswresample -lm/Libs: -L\${libdir}  -lswresample -lm -lsoxr/g" $LOCALDESTDIR/lib/pkgconfig/libswresample.pc
 
             do_checkIfExist ffmpeg-git libavcodec.a

--- a/media-suite_compile.sh
+++ b/media-suite_compile.sh
@@ -1997,6 +1997,11 @@ if [[ $ffmpeg = "y" ]] || [[ $ffmpeg = "s" ]]; then
             arch='x86_64'
         fi
 
+        if [[ ! -f "ffmpeg-use-pkg-config-for-more-external-libs.patch" ]]; then
+            do_wget "https://raw.github.com/jb-alvarado/media-autobuild_suite/master/patches/ffmpeg-use-pkg-config-for-more-external-libs.patch"
+        fi
+        patch -N -p0 < ffmpeg-use-pkg-config-for-more-external-libs.patch
+
         if [[ $ffmpeg = "s" ]]; then
             if [ -f "$LOCALDESTDIR/bin-video/ffmpegSHARED/bin/ffmpeg.exe" ]; then
                 rm -rf $LOCALDESTDIR/bin-video/ffmpegSHARED

--- a/media-suite_compile.sh
+++ b/media-suite_compile.sh
@@ -705,12 +705,12 @@ if [[ $compile = "true" ]]; then
         rm -f $LOCALDESTDIR/bin-audio/dcadec.exe
     fi
 
-    if [[ -f dcadec.exe ]]; then
+    if [[ -f libdcadec/libdcadec.a ]]; then
         make clean
     fi
 
-    make CONFIG_WINDOWS=1 LDFLAGS=-lm
-    make PREFIX=$LOCALDESTDIR BINDIR=$LOCALDESTDIR/bin-audio PKG_CONFIG_PATH=$LOCALDESTDIR/lib/pkgconfig install
+    make CONFIG_WINDOWS=1 LDFLAGS=-lm lib
+    make PREFIX=$LOCALDESTDIR PKG_CONFIG_PATH=$LOCALDESTDIR/lib/pkgconfig install-lib
 
     do_checkIfExist dcadec-git libdcadec.a
 fi

--- a/patches/ffmpeg-use-pkg-config-for-more-external-libs.patch
+++ b/patches/ffmpeg-use-pkg-config-for-more-external-libs.patch
@@ -1,0 +1,50 @@
+--- configure.orig  2015-05-24 19:43:35.249995200 +0100
++++ configure   2015-05-24 19:43:43.027493900 +0100
+@@ -5047,14 +5047,14 @@
+ enabled libcaca           && require_pkg_config caca caca.h caca_create_canvas
+ enabled libdcadec         && require_pkg_config dcadec libdcadec/dca_context.h dcadec_context_create
+ enabled libfaac           && require2 libfaac "stdint.h faac.h" faacEncGetVersion -lfaac
+-enabled libfdk_aac        && require libfdk_aac fdk-aac/aacenc_lib.h aacEncOpen -lfdk-aac
++enabled libfdk_aac        && require_pkg_config fdk-aac fdk-aac/aacenc_lib.h aacEncOpen
+ flite_libs="-lflite_cmu_time_awb -lflite_cmu_us_awb -lflite_cmu_us_kal -lflite_cmu_us_kal16 -lflite_cmu_us_rms -lflite_cmu_us_slt -lflite_usenglish -lflite_cmulex -lflite"
+ enabled libflite          && require2 libflite "flite/flite.h" flite_init $flite_libs
+ enabled fontconfig        && enable libfontconfig
+ enabled libfontconfig     && require_pkg_config fontconfig "fontconfig/fontconfig.h" FcInit
+ enabled libfreetype       && require_libfreetype
+ enabled libfribidi        && require_pkg_config fribidi fribidi.h fribidi_version_info
+-enabled libgme            && require  libgme gme/gme.h gme_new_emu -lgme -lstdc++
++enabled libgme            && require_pkg_config libgme gme/gme.h gme_new_emu
+ enabled libgsm            && { for gsm_hdr in "gsm.h" "gsm/gsm.h"; do
+                                    check_lib "${gsm_hdr}" gsm_create -lgsm && break;
+                                done || die "ERROR: libgsm not found"; }
+@@ -5063,8 +5063,8 @@
+ enabled libmodplug        && require_pkg_config libmodplug libmodplug/modplug.h ModPlug_Load
+ enabled libmp3lame        && require "libmp3lame >= 3.98.3" lame/lame.h lame_set_VBR_quality -lmp3lame
+ enabled libnut            && require libnut libnut.h nut_demuxer_init -lnut
+-enabled libopencore_amrnb && require libopencore_amrnb opencore-amrnb/interf_dec.h Decoder_Interface_init -lopencore-amrnb
+-enabled libopencore_amrwb && require libopencore_amrwb opencore-amrwb/dec_if.h D_IF_init -lopencore-amrwb
++enabled libopencore_amrnb && require_pkg_config opencore-amrnb opencore-amrnb/interf_dec.h Decoder_Interface_init
++enabled libopencore_amrwb && require_pkg_config opencore-amrwb opencore-amrwb/dec_if.h D_IF_init
+ enabled libopencv         && require_pkg_config opencv opencv/cxcore.h cvCreateImageHeader
+ enabled libopenh264       && require_pkg_config openh264 wels/codec_api.h WelsGetCodecVersion
+ enabled libopenjpeg       && { check_lib openjpeg.h opj_version -lopenmj2 -DOPJ_STATIC ||
+@@ -5085,8 +5085,8 @@
+ enabled libstagefright_h264 && require_cpp libstagefright_h264 "binder/ProcessState.h media/stagefright/MetaData.h
+     media/stagefright/MediaBufferGroup.h media/stagefright/MediaDebug.h media/stagefright/MediaDefs.h
+     media/stagefright/OMXClient.h media/stagefright/OMXCodec.h" android::OMXClient -lstagefright -lmedia -lutils -lbinder -lgnustl_static
+-enabled libtheora         && require libtheora theora/theoraenc.h th_info_init -ltheoraenc -ltheoradec -logg
+-enabled libtwolame        && require libtwolame twolame.h twolame_init -ltwolame &&
++enabled libtheora         && require_pkg_config theoraenc theora/theoraenc.h th_info_init
++enabled libtwolame        && require_pkg_config twolame twolame.h twolame_init &&
+                              { check_lib twolame.h twolame_encode_buffer_float32_interleaved -ltwolame ||
+                                die "ERROR: libtwolame must be installed and version must be >= 0.3.10"; }
+ enabled libutvideo        && require_cpp utvideo "stdint.h stdlib.h utvideo/utvideo.h utvideo/Codec.h" 'CCodec*' -lutvideo -lstdc++
+@@ -5094,7 +5094,7 @@
+ enabled libvidstab        && require_pkg_config "vidstab >= 0.98" vid.stab/libvidstab.h vsMotionDetectInit
+ enabled libvo_aacenc      && require libvo_aacenc vo-aacenc/voAAC.h voGetAACEncAPI -lvo-aacenc
+ enabled libvo_amrwbenc    && require libvo_amrwbenc vo-amrwbenc/enc_if.h E_IF_init -lvo-amrwbenc
+-enabled libvorbis         && require libvorbis vorbis/vorbisenc.h vorbis_info_init -lvorbisenc -lvorbis -logg
++enabled libvorbis         && require_pkg_config vorbisenc vorbis/vorbisenc.h vorbis_info_init
+ enabled libvpx            && {
+     enabled libvpx_vp8_decoder && { check_lib2 "vpx/vpx_decoder.h vpx/vp8dx.h" vpx_codec_dec_init_ver -lvpx ||
+                                     die "ERROR: libvpx decoder version must be >=0.9.1"; }


### PR DESCRIPTION
FFmbc can be left as is since it's based on an old version of FFmpeg, so things might or not break if we take extra-libs off, but I just finished a full compilation from scratch and there were no problems.

How about on your side, @jb-alvarado ?