### PR TITLE
Mkvtoolnix Qt GUI

### DIFF
--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -662,8 +662,9 @@ if %mkvINI%==0 (
     echo -------------------------------------------------------------------------------
     echo.
     echo. Build static mkvtoolnix binaries?
-    echo. 1 = Yes
+    echo. 1 = Yes (Qt GUI^)
     echo. 2 = No
+    echo. 3 = Yes (wxGTK and Qt GUI^)
     echo.
     echo -------------------------------------------------------------------------------
     echo -------------------------------------------------------------------------------
@@ -678,9 +679,11 @@ if %buildmkv%==1 (
     )
 if %buildmkv%==2 (
     set "mkv=n"
-    set "mingwpackages=%mingwpackages% qt5-static"
     )
-if %buildmkv% GTR 2 GOTO mkv
+if %buildmkv%==3 (
+    set "mkv=b"
+    )
+if %buildmkv% GTR 3 GOTO mkv
 if %writeMKV%==yes echo.mkv=^%buildmkv%>>%ini%
 
 :numCores

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -678,6 +678,7 @@ if %buildmkv%==1 (
     )
 if %buildmkv%==2 (
     set "mkv=n"
+    set "mingwpackages=%mingwpackages% qt5-static"
     )
 if %buildmkv% GTR 2 GOTO mkv
 if %writeMKV%==yes echo.mkv=^%buildmkv%>>%ini%


### PR DESCRIPTION
Qt version of mkvtoolnix's GUI has come out of alpha. After 8.0.0, the wxGTK version will be considered deprecated.

Problems with this:
We need either to compile qtbase (just `make clean` takes ages) for ourselves or install `qt5-static`.
Compiling by ourselves takes a buttload of time to make and clean but we get a lighter version of qt.
Installing qt5-static we add a 500MB download and 3GB install size just from that, but I've confirmed installation works with the latter.
I haven't been able to finish the compilation of Qt yet, and I don't think it's worth it.

To prevent this 3GB behemoth from getting installed even if you aren't compiling mkvtoolnix, we could add a mechanism to only install it if mkvtoolnix is selected.