### PR TITLE
modified:   media-autobuild_suite.bat

### DIFF
--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -624,7 +624,9 @@ if exist "%instdir%\%msys2%\msys2_shell.bat" GOTO getMintty
     echo.- Download and install msys2 basic system
     echo.
     echo -------------------------------------------------------------------------------
-    if %msys2%==msys32 (set "msysprefix=i686" ) else (set "msysprefix=x86_64")
+    if %msys2%==msys32 (
+	set "msysprefix=i686"
+	) else set "msysprefix=x86_64"
     set "msysbase=https://www.mirrorservice.org/sites/download.sourceforge.net/pub/sourceforge/m/ms/msys2/Base/%msysprefix%"
     for /F %%b in (
         '%build%\wget --no-check-certificate -qO- "%msysbase%/?C=M;O=D" ^| ^


### PR DESCRIPTION
Fix for msys installation script break due to syntax.
![1442799612](https://cloud.githubusercontent.com/assets/13444519/9984152/b224bc90-5fe0-11e5-989d-19e5de499019.png)