### PR TITLE
Replaces the git repository for dvdread

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -724,7 +724,7 @@ fi
 if [[ $mplayer = "y" ]] ||
     { [[ $mpv = "y" ]] && do_checkForOptions "--enable-libbluray"; }; then
     cd $LOCALBUILDDIR
-    do_vcs "http://git.videolan.org/git/libdvdread.git" dvdread
+    do_vcs "https://github.com/mirror/libdvdread.git" dvdread
     if [[ $compile = "true" ]]; then
         do_autoreconf
         [[ -f Makefile ]] && log "distclean" make distclean


### PR DESCRIPTION
Since videolan git repository for dvdread seems to be unavailable, I
suggest to replace it with a mirror.