### PR TITLE
Fallback patch location to build/ folder

### DIFF
--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -930,6 +930,7 @@ do_patch() {
     [[ $patch = ${patch##*/} ]] &&
         patch="/patches/$patch"
     do_wget -c -r -q "$patch"
+    [[ ! -f "$patch" ]] && patch=${patch##*/}
     if [[ -f "$patch" ]]; then
         if [[ "$am" = "am" ]]; then
             if ! git am -q --ignore-whitespace "$patch" >/dev/null 2>&1; then


### PR DESCRIPTION
wget downloads patches to the lib's subfolder within /build but the next test looks in /patches which doesn't exist. This patch strips leading path if patch isn't found in /patches