### PR TITLE
Switch to libopenmpt latest git release

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -667,7 +667,8 @@ unset _deps
 
 _check=(libopenmpt.{a,pc})
 if [[ $ffmpeg != "no" ]] && enabled libopenmpt &&
-    do_vcs "https://github.com/OpenMPT/openmpt.git#tag=LATEST"; then
+    do_vcs "https://github.com/OpenMPT/openmpt.git"; then
+    git checkout -qf --no-track -B master $(git tag -l "libopenmpt*" --sort=-creatordate | head -n 1)
     do_uninstall include/libopenmpt "${_check[@]}"
     [[ -d bin ]] || mkdir bin
     extracommands=(CONFIG="mingw64-win${bits%bit}" AR=ar STATIC_LIB=1 EXAMPLES=0 OPENMPT123=0


### PR DESCRIPTION
Since the openmpt git repo seems to have non-linear history, use an alternative method to switch to latest release