### PR TITLE
aacs: add needed ws2_32 to gpg-error-config

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -883,6 +883,8 @@ if { [[ $ffmpeg != "no" ]] && enabled libbluray; } || ! mpv_disabled libbluray; 
     do_pacman_install libgcrypt
     grep -q ws2_32 "$MINGW_PREFIX/bin/libgcrypt-config" ||
         sed -i 's;gpg-error;& -lws2_32;' "$MINGW_PREFIX/bin/libgcrypt-config"
+    grep -q ws2_32 "$MINGW_PREFIX/bin/gpg-error-config" ||
+        sed -i 's;lgpg-error;& -lws2_32;' "$MINGW_PREFIX/bin/gpg-error-config"
     _check=(bin-video/libaacs.dll libaacs.{{,l}a,pc} libaacs/aacs.h)
     if do_vcs "https://git.videolan.org/git/libaacs.git"; then
         sed -ri 's;bin_PROGRAMS.*;bin_PROGRAMS = ;' Makefile.am

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -885,7 +885,7 @@ if { [[ $ffmpeg != "no" ]] && enabled libbluray; } || ! mpv_disabled libbluray; 
         sed -i 's;gpg-error;& -lws2_32;' "$MINGW_PREFIX/bin/libgcrypt-config"
     grep -q ws2_32 "$MINGW_PREFIX/bin/gpg-error-config" ||
         sed -i 's;lgpg-error;& -lws2_32;' "$MINGW_PREFIX/bin/gpg-error-config"
-    _check=(bin-video/libaacs.dll libaacs.dll.a libaacs.{{,l}a,pc} libaacs/aacs.h)
+    _check=(bin-video/libaacs.dll libaacs.{{,dll.,l}a,pc} libaacs/aacs.h)
     if do_vcs "https://git.videolan.org/git/libaacs.git"; then
         sed -ri 's;bin_PROGRAMS.*;bin_PROGRAMS = ;' Makefile.am
         do_autoreconf

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -885,7 +885,7 @@ if { [[ $ffmpeg != "no" ]] && enabled libbluray; } || ! mpv_disabled libbluray; 
         sed -i 's;gpg-error;& -lws2_32;' "$MINGW_PREFIX/bin/libgcrypt-config"
     grep -q ws2_32 "$MINGW_PREFIX/bin/gpg-error-config" ||
         sed -i 's;lgpg-error;& -lws2_32;' "$MINGW_PREFIX/bin/gpg-error-config"
-    _check=(bin-video/libaacs.dll libaacs.{{,l}a,pc} libaacs/aacs.h)
+    _check=(bin-video/libaacs.dll libaacs.dll.a libaacs.{{,l}a,pc} libaacs/aacs.h)
     if do_vcs "https://git.videolan.org/git/libaacs.git"; then
         sed -ri 's;bin_PROGRAMS.*;bin_PROGRAMS = ;' Makefile.am
         do_autoreconf


### PR DESCRIPTION
See my comment: https://github.com/jb-alvarado/media-autobuild_suite/commit/d32209912d1de07e19573c9aac62ad8889abe1b1