### PR TITLE
MPV 64bit : added cflag -DARCH_X86_64=1 to use correct "nvEncodeAPI64.dll

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1730,6 +1730,10 @@ if [[ $mpv != "n" ]] && pc_exists libavcodec libavformat libswscale libavfilter;
                 mpv_cflags=("-I$(cygpath -sm "$CUDA_PATH")/include")
                 mpv_ldflags+=("-L$(cygpath -sm "$CUDA_PATH")/lib/x64")
             fi
+            mpv_cflags+=("-DARCH_X86_64=1")
+            export ARCH_X86_64=1
+        else
+            unset ARCH_X86_64
         fi
         enabled libssh && mpv_ldflags+=("-Wl,--allow-multiple-definition")
         if ! mpv_disabled manpage-build || mpv_enabled html-build; then
@@ -1758,7 +1762,7 @@ if [[ $mpv != "n" ]] && pc_exists libavcodec libavformat libswscale libavfilter;
         log install /usr/bin/python waf -j1 install ||
             log install /usr/bin/python waf -j1 install
 
-        unset mpv_ldflags replace
+        unset mpv_ldflags mpv_cflags replace ARCH_X86_64
         hide_conflicting_libs -R
         files_exist share/man/man1/mpv.1 && dos2unix -q "$LOCALDESTDIR"/share/man/man1/mpv.1
         ! mpv_disabled debug-build &&


### PR DESCRIPTION
When compiling MPV 64bit, you'll notice a warning that "if ARCH_X86_64" evaluates to zero (wundef).
If you look at the code from **\build\nv-codec-headers-git\include\ffnvcodec\dynlink_loader.h** you will see that this prevents using the 64 bit version from "nvEncodeAPI64.dll" and instead the 32 bit version"nvEncodeAPI.dll"will be used to compile a 64 bit program!
Obviously this can never work.
Adding the cflag -DARCH_X86_64=1 solves this problem.

```
#if defined(_WIN32) || defined(__CYGWIN__)
# define CUDA_LIBNAME "nvcuda.dll"
# define NVCUVID_LIBNAME "nvcuvid.dll"
# if ARCH_X86_64
#  define NVENC_LIBNAME "nvEncodeAPI64.dll"
# else
#  define NVENC_LIBNAME "nvEncodeAPI.dll"
# endif
#else
# define CUDA_LIBNAME "libcuda.so.1"
# define NVCUVID_LIBNAME "libnvcuvid.so.1"
# define NVENC_LIBNAME "libnvidia-encode.so.1"
#endif

