### PR TITLE
Both libaom and libxvid shall belong to Zeranoe builds

### DIFF
--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -74,17 +74,17 @@ set ffmpeg_options_builtin=#amf #bzlib #cuda #cuvid #d3d11va #dxva2 ^
 set ffmpeg_options_basic=gmp libmp3lame libopus libvorbis libvpx libx264 libx265
 
 :: options used in zeranoe builds and not present above
-set ffmpeg_options_zeranoe=fontconfig gnutls libass libbluray libfreetype ^
+set ffmpeg_options_zeranoe=fontconfig gnutls libass libaom libbluray libfreetype ^
 libmfx libmysofa libopencore-amrnb libopencore-amrwb libopenjpeg libsnappy ^
-libsoxr libspeex libtheora libtwolame libvidstab libvo-amrwbenc libwavpack ^
+libsoxr libspeex libtheora libtwolame libvidstab libxvid libvo-amrwbenc libwavpack ^
 libwebp libxml2 libzimg libshine gpl openssl libtls avisynth mbedtls
 
 :: options also available with the suite
 set ffmpeg_options_full=chromaprint cuda-sdk decklink frei0r libbs2b libcaca ^
 libcdio libfdk-aac libflite libfribidi libgme libgsm libilbc libkvazaar ^
 libmodplug libnpp libopenh264 libopenmpt librtmp librubberband libssh ^
-libtesseract libxavs libxvid libzmq libzvbi opencl opengl libvmaf libcodec2 ^
-libsrt libaom ladspa vapoursynth
+libtesseract libxavs libzmq libzvbi opencl opengl libvmaf libcodec2 ^
+libsrt ladspa vapoursynth
 
 :: built-ins
 set mpv_options_builtin=#cplayer #manpage-build #lua #javascript #libass ^


### PR DESCRIPTION
Moved both libraries from ffmpeg_options_full to ffmpeg_options_zeranoe to resemble better the current subset of GPLv3 ffmpeg builds as published on the Zeranoe website.