### PR TITLE
media-suite_compile.sh changes

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1708,7 +1708,7 @@ if [[ $mpv != "n" ]] && pc_exists libavcodec libavformat libswscale libavfilter;
             fi
         }
 
-        add_third_party "https://github.com/google/glslang.git"
+        add_third_party "https://github.com/KhronosGroup/glslang.git"
         add_third_party "https://github.com/KhronosGroup/SPIRV-Tools.git" spirv-tools
         add_third_party "https://github.com/KhronosGroup/SPIRV-Headers.git" spirv-headers
 

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1727,7 +1727,7 @@ if [[ $mpv != "n" ]] && pc_exists libavcodec libavformat libswscale libavfilter;
     if ! mpv_disabled crossc &&
         do_vcs "https://github.com/rossy/crossc"; then
         do_uninstall "${_check[@]}"
-        log submodule git submodule update --init
+        log submodule git submodule update --init --recursive --remote
         log clean make clean
         do_make install-static prefix="$LOCALDESTDIR"
         do_checkIfExist


### PR DESCRIPTION
1. I don't see why use Google's repo for glslang but KhronosGroup's for other dependencies. Google basically just pulls from KhronosGroups's repo with no changes once a week or so.

2. crossc uses SPIRV-Cross as its submodule which is always pointing to the same SPIRV-Cross's commit. Since the owner of crossc repo doesn't update his repo frequently it can potentially lead to some problems, see: https://github.com/mpv-player/mpv/issues/5760 So change it to always pull the latest SPIRV-Cross.