### PR TITLE
AOM with no-tree-slp-vectorize for GCC 8.2.0

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -819,7 +819,12 @@ _check=(libaom.a aom.pc)
 [[ -n $_aom_bins ]] && _check+=(bin-video/aomenc.exe)
 if { [[ $aom = y ]] || { [[ $ffmpeg != "no" ]] && enabled libaom; }; } &&
     do_vcs https://aomedia.googlesource.com/aom; then
-    extracommands=()
+# as long as GCC 8.2.0 is only used in MinGW64, and only 8.2.0 produces instructions with unaligned memory access:
+    if [[ $bits = 32bit ]]; then
+        extracommands=()
+    else
+        extracommands=(-DAOM_EXTRA_C_FLAGS="-fno-tree-slp-vectorize" -DAOM_EXTRA_CXX_FLAGS="-fno-tree-slp-vectorize")
+    fi
     [[ -n $_aom_bins ]] && _check+=(bin-video/aomdec.exe) ||
         extracommands+=(-DENABLE_EXAMPLES=off)
     do_uninstall include/aom "${_check[@]}"


### PR DESCRIPTION
To avoid aomenc failing with segmentation faults during encoding when it is built with GCC 8.2.0 (currently only in MinGW64 in the MSYS2 project), the compiler flag -fno-tree-slp-vectorize could be added for GNU C/C++ compilers. The crash is caused by the compiler producing instructions with unaligned memory access.