### PR TITLE
Revert "tesseract: clamp to older commit"

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -388,7 +388,7 @@ if [[ $ffmpeg != "no" || $standalone = y ]] && enabled libtesseract; then
     fi
 
     _check=(libtesseract.{,l}a tesseract.pc)
-    if do_vcs "https://github.com/tesseract-ocr/tesseract.git#commit=8d3f811"; then
+    if do_vcs "https://github.com/tesseract-ocr/tesseract.git"; then
         do_autogen
         _check+=(bin-global/tesseract.exe)
         do_uninstall include/tesseract "${_check[@]}"


### PR DESCRIPTION
It's working again, compilation of lib went through without any further changes, ffpmeg built OK as well.