### PR TITLE
Disable http related opus tools features

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -599,7 +599,7 @@ if [[ $standalone = y ]] && enabled libopus; then
     if do_vcs "https://github.com/xiph/opusfile.git"; then
         do_uninstall "${_check[@]}"
         do_autogen
-        do_separate_confmakeinstall --disable-{examples,doc}
+        do_separate_confmakeinstall --disable-{http,examples,doc}
         do_checkIfExist
     fi
 
@@ -608,7 +608,7 @@ if [[ $standalone = y ]] && enabled libopus; then
     if do_vcs "https://github.com/xiph/libopusenc.git"; then
         do_uninstall "${_check[@]}"
         do_autogen
-        do_separate_confmakeinstall --disable-{examples,doc}
+        do_separate_confmakeinstall --disable-{http,examples,doc}
         do_checkIfExist
     fi
 


### PR DESCRIPTION
Temporary workaround to avoid incompatibility issues with OpenSSL 1.1 – based on changes suggested by @slyfox1186 in https://github.com/jb-alvarado/media-autobuild_suite/issues/930#issuecomment-424733584