### PR TITLE
Ignore Windows PYTHONPATH during build

### DIFF
--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -1588,6 +1588,8 @@ goto :EOF
     echo.
     echo.export CARGO_HOME="/opt/cargo" RUSTUP_HOME="/opt/cargo"
     echo.
+    echo.export PYTHONPATH=
+    echo.
     echo.LANG=en_US.UTF-8
     echo.PATH="${LOCALDESTDIR}/bin:${MINGW_PREFIX}/bin:${INFOPATH}:${MSYS2_PATH}:${ORIGINAL_PATH}"
     echo.PATH="${LOCALDESTDIR}/bin-audio:${LOCALDESTDIR}/bin-global:${LOCALDESTDIR}/bin-video:${PATH}"


### PR DESCRIPTION
Python/Meson will not run/crash/segfault if PYTHONPATH from Windows is used. If Windows PYTHONPATH would be somewhere required during building it's always possible to query the Windows registry for it.