### PR TITLE
Cyanrip: replace yes and no with y and n, also remove extra tabs in whitespace.

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1983,7 +1983,7 @@ if [[ $bmx = "y" ]]; then
 fi
 enabled openssl && hide_libressl -R
 
-if [[ $cyanrip = yes ]]; then
+if [[ $cyanrip = y ]]; then
     do_pacman_install libxml2
     do_pacman_install libcdio-paranoia
     sed -ri 's;-R[^ ]*;;g' "$MINGW_PREFIX/lib/pkgconfig/libcdio.pc"

--- a/build/media-suite_update.sh
+++ b/build/media-suite_update.sh
@@ -63,9 +63,8 @@ fi # end suite update
 # packet update system
 # --------------------------------------------------
 
-/usr/bin/grep -q AE4FF531 <(pacman-key -l) || pacman-key --recv-keys AE4FF531
-/usr/bin/grep -q 'full.*wiiaboo@gmail.com' <(pacman-key -l) ||
-    pacman-key --lsign AE4FF531
+/usr/bin/pacman-key -f EFD16019AE4FF531 || pacman-key -r EFD16019AE4FF531
+/usr/bin/pacman-key --list-sigs AE4FF531 | grep -q pacman@localhost || pacman-key --lsign AE4FF531
 
 #always kill gpg-agent
 ps|grep gpg-agent|awk '{print $1}'|xargs kill -9

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -878,8 +878,8 @@ if %cyanrip2INI%==0 (
     ) else set buildcyanrip=%cyanrip2INI%
 if %deleteINI%==1 set "writecyanrip=yes"
 
-if %buildcyanrip%==1 set "cyanrip=yes"
-if %buildcyanrip%==2 set "cyanrip=no"
+if %buildcyanrip%==1 set "cyanrip=y"
+if %buildcyanrip%==2 set "cyanrip=n"
 if %buildcyanrip% GTR 2 GOTO cyanrip
 if %writecyanrip%==yes echo.cyanrip2=^%buildcyanrip%>>%ini%
 
@@ -1173,7 +1173,7 @@ if exist "%instdir%\%msys2%\msys2_shell.cmd" GOTO getMintty
         ) else set "msysprefix=x86_64"
     wget --tries=5 --retry-connrefused --waitretry=5 --continue -O msys2-base.tar.xz ^
     "http://repo.msys2.org/distrib/msys2-%msysprefix%-latest.tar.xz"
-    
+
 :unpack
 if exist %build%\msys2-base.tar.xz (
     %build%\7za.exe x msys2-base.tar.xz -so | %build%\7za.exe x -aoa -si -ttar -o..
@@ -1384,7 +1384,7 @@ if %build32%==yes (
     if exist %build%\mingw32.log del %build%\mingw32.log
     %mintty% --log 2>&1 %build%\mingw32.log /usr/bin/bash --login %build%\mingw32.sh
     del %build%\mingw32.sh
-    
+
     if not exist %instdir%\%msys2%\mingw32\bin\gcc.exe (
         echo -------------------------------------------------------------------------------
         echo.
@@ -1399,7 +1399,7 @@ if %build32%==yes (
             ) else exit
         )
     )
-    
+
 :getmingw64
 if %build64%==yes (
     if exist %instdir%\%msys2%\mingw64\bin\gcc.exe GOTO updatebase


### PR DESCRIPTION
Change cyanrip's variables to match the others and the removal of the tabs in the white space was caused by visual studio code.