### PR TITLE
batch: Removed standalone keyword from Kvazaar.

### DIFF
--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -400,7 +400,7 @@ if %other265INI%==0 (
     echo -------------------------------------------------------------------------------
     echo -------------------------------------------------------------------------------
     echo.
-    echo. Build standalone Kvazaar? [H.265 encoder]
+    echo. Build Kvazaar? [H.265 encoder]
     echo. 1 = Yes
     echo. 2 = No
     echo.


### PR DESCRIPTION
Since kvazaar can be built with ffmpeg, I removed the standalone word from the question since it seemed like it implied that kvazaar can only be built as a standalone exe and could not be included anywhere else.