### PR TITLE
update.sh: (re-)enable IgnorePkg option in /etc/pacman.conf

### DIFF
--- a/build/media-suite_update.sh
+++ b/build/media-suite_update.sh
@@ -170,7 +170,7 @@ fi
 # packet msys2 system
 # --------------------------------------------------
 
-have_updates="$(pacman -Quq)"
+have_updates="$(pacman -Qu|grep -v ignored]$|awk '{print $1}')"
 if [[ -n "$have_updates" ]]; then
     echo "-------------------------------------------------------------------------------"
     echo "Updating msys2 system and installed packages..."
@@ -180,7 +180,6 @@ if [[ -n "$have_updates" ]]; then
         have_updates="$(echo "$have_updates" | /usr/bin/grep -Ev '^(pacman|bash|msys2-runtime)$')"
     echo $have_updates | xargs $nargs pacman -S --noconfirm --ask 20 \
         --overwrite "/mingw64/*" --overwrite "/mingw32/*" --overwrite "/usr/*"
-    sed -i "s;^IgnorePkg.*;#&;" /etc/pacman.conf
 fi
 
 [[ ! -s /usr/ssl/certs/ca-bundle.crt ]] &&


### PR DESCRIPTION
We shouldn't play with that option, anyone who wants to downgrade/ignore new *crap* packages for a while like currently in the zeromq case should be able to revert to a previous working package. If necessary add the list of installed packages to the error log(s) instead if this is required for problem analysis  :+1: