### PR TITLE
Batch: Use Invoke-WebRequest instead of Net.WebClient

### DIFF
--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -1151,13 +1151,7 @@ if exist %build%\wget.exe if exist %build%\7za.exe if exist %build%\grep.exe GOT
 
 setlocal enabledelayedexpansion
 if not exist %build%\wget.exe (
-    (
-        echo.[System.Net.ServicePointManager]::SecurityProtocol = 'Tls12'
-        echo.$wc = New-Object System.Net.WebClient
-        echo.$wc.DownloadFile^('https://i.fsbn.eu/pub/wget-pack.exe', "$PWD\wget-pack.exe"^)
-        )>wget.ps1
-    powershell -noprofile -executionpolicy bypass .\wget.ps1
-    del wget.ps1
+    powershell -noprofile -command Invoke-WebRequest -UseBasicParsing -Uri "https://i.fsbn.eu/pub/wget-pack.exe" -OutFile "$PWD\wget-pack.exe"
 
     for /f "tokens=1 delims=" %%a ^
 in ('powershell -noprofile -command "(get-filehash -algorithm sha256 wget-pack.exe).hash"') do set _hash=%%a

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -1154,7 +1154,7 @@ if not exist %build%\wget.exe (
     powershell -noprofile -command Invoke-WebRequest -UseBasicParsing -Uri "https://i.fsbn.eu/pub/wget-pack.exe" -OutFile "$PWD\wget-pack.exe"
 
     for /f "tokens=1 delims=" %%a ^
-in ('powershell -noprofile -command "(get-filehash -algorithm sha256 wget-pack.exe).hash"') do set _hash=%%a
+in ('powershell -noprofile -command "(get-filehash wget-pack.exe).hash"') do set _hash=%%a
 
     if ["!_hash!"]==["3F226318A73987227674A4FEDDE47DF07E85A48744A07C7F6CDD4F908EF28947"] (
         %build%\wget-pack.exe x

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -1151,7 +1151,8 @@ if exist %build%\wget.exe if exist %build%\7za.exe if exist %build%\grep.exe GOT
 
 setlocal enabledelayedexpansion
 if not exist %build%\wget.exe (
-    powershell -noprofile -command Invoke-WebRequest -UseBasicParsing -Uri "https://i.fsbn.eu/pub/wget-pack.exe" -OutFile "$PWD\wget-pack.exe"
+    powershell -noprofile -command [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12;^
+     Invoke-WebRequest -UseBasicParsing -Uri "https://i.fsbn.eu/pub/wget-pack.exe" -OutFile "$PWD\wget-pack.exe"
 
     for /f "tokens=1 delims=" %%a ^
 in ('powershell -noprofile -command "(get-filehash wget-pack.exe).hash"') do set _hash=%%a


### PR DESCRIPTION
Since we are using powershell version 4 as a requirement (Based on get-filehash only being available from 4), we can use invoke-webrequest instead of the System.Net.WebClient.
Also removed algorithm arg from get-filehash since the default since its conception has been sha256.