### PR TITLE
Batch: Modified logic for checking INI due to how errorlevel works

### DIFF
--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -128,11 +128,12 @@ if exist %ini% GOTO checkINI
 set deleteIni=0
 for %%a in (%iniOptions%) do (
     findstr %%a %ini% > nul
-    if errorlevel 1 set deleteIni=1 && set %%aINI=0
-    if errorlevel 0 for /F "tokens=2 delims==" %%b in ('findstr %%a %ini%') do (
-        set %%aINI=%%b
-        if %%b==0 set deleteIni=1
-        )
+    if %ERRORLEVEL% EQU 0 (
+        for /F "tokens=2 delims==" %%b in ('findstr %%a %ini%') do (
+            set %%aINI=%%b
+            if %%b==0 set deleteIni=1
+            )
+        ) else set deleteIni=1 && set %%aINI=0
     )
 if %deleteINI%==1 (
     del %ini%


### PR DESCRIPTION
Based on warnings from <https://www.robvanderwoude.com/battech_batcodecheck.php> and <https://ss64.com/nt/errorlevel.html>. Using if errorlevel 0 checks for any errorlevel greater than or equal to 0 (including if the command gave an errorlevel of 1), instead of if the previous command did not error.