### PR TITLE
Update.sh: Added autoyes if pacman can't find abrepo key. 

### DIFF
--- a/build/media-suite_update.sh
+++ b/build/media-suite_update.sh
@@ -64,7 +64,7 @@ fi # end suite update
 # --------------------------------------------------
 
 /usr/bin/pacman-key -f EFD16019AE4FF531 || pacman-key -r EFD16019AE4FF531 >/dev/null
-/usr/bin/pacman-key --list-sigs AE4FF531 | grep -q pacman@localhost || pacman-key --lsign AE4FF531
+/usr/bin/pacman-key --list-sigs AE4FF531 | grep -q pacman@localhost || pacman-key --lsign AE4FF531 >/dev/null
 
 #always kill gpg-agent
 ps|grep gpg-agent|awk '{print $1}'|xargs kill -9
@@ -88,7 +88,7 @@ echo "Updating pacman database..."
 echo "-------------------------------------------------------------------------------"
 echo
 
-pacman -Sy
+pacman -Sy --ask=20 --noconfirm
 pacman -Qqe | grep -q sed && pacman -Qqg base | pacman -D --asdeps - && pacman -D --asexplicit mintty flex > /dev/null
 do_unhide_all_sharedlibs
 if [[ -f /etc/pac-base.pk ]] && [[ -f /etc/pac-mingw.pk ]]; then


### PR DESCRIPTION
Should fix the problem mentioned by @schmidthubert in https://github.com/jb-alvarado/media-autobuild_suite/pull/1042 with pacman asking if the key should be imported.
Added another >/dev/null for the pacman-key.