### PR TITLE
Batch: Added quotes around minttyrc in case of a username with spaces

### DIFF
--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -1334,7 +1334,7 @@ if not exist %instdir%\mintty.lnk (
     )
 
     if not exist "%instdir%\%msys2%\home\%USERNAME%" mkdir "%instdir%\%msys2%\home\%USERNAME%"
-    for /F "tokens=2 delims==" %%b in ('findstr /i TERM %instdir%\%msys2%\home\%USERNAME%\.minttyrc') do set TERM=%%b
+    for /F "tokens=2 delims==" %%b in ('findstr /i TERM "%instdir%\%msys2%\home\%USERNAME%\.minttyrc"') do set TERM=%%b
     if not defined TERM (
         %instdir%\%msys2%\usr\bin\bash.exe -lc "printf '%%s\n' Locale=en_US Charset=UTF-8 Font=Consolas Columns=120 Rows=30 TERM=xterm-256color>/home/%USERNAME%/.minttyrc"
     )


### PR DESCRIPTION
I think this should fix blackscreen's problem of minttyrc being rewritten to due to a space in his name. 