### PR TITLE
Batch: Changed one of the setlocal in writeOption to endlocal

### DIFF
--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -1758,5 +1758,5 @@ for %%i in (%*) do (
         echo --enable-!_opt!
     )
 )
-setlocal
+endlocal
 goto :EOF


### PR DESCRIPTION
Idk if this is necessary. Felt weird because it keeps on setting a local environment everytime write Option is called in the options file without ending the local environment part.