### PR TITLE
Batch: Condensed msys2Arch

### DIFF
--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -153,8 +153,7 @@ if %deleteINI%==1 (
 
 :systemVars
 set msys2Arch=%msys2ArchINI%
-if %msys2Arch%==1 set "msys2=msys32"
-if %msys2Arch%==2 set "msys2=msys64"
+if %msys2Arch%==1 ( set "msys2=msys32") else set "msys2=msys64"
 
 setlocal
 


### PR DESCRIPTION
Since msys2Arch can really only be one of two values.