### PR TITLE
frei0r: fix building

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1144,6 +1144,7 @@ if [[ $ffmpeg != "no" ]] && enabled_any frei0r ladspa; then
     if do_vcs https://github.com/dyne/frei0r.git; then
         sed -i 's/find_package (Cairo)//' "CMakeLists.txt"
         do_uninstall lib/frei0r-1 "${_check[@]}"
+        do_pacman_install gavl
         do_cmakeinstall
         do_checkIfExist
     fi

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1145,7 +1145,7 @@ if [[ $ffmpeg != "no" ]] && enabled_any frei0r ladspa; then
         sed -i 's/find_package (Cairo)//' "CMakeLists.txt"
         do_uninstall lib/frei0r-1 "${_check[@]}"
         do_pacman_install gavl
-        do_cmakeinstall
+        do_cmakeinstall -DWITHOUT_OPENCV=on
         do_checkIfExist
     fi
 fi


### PR DESCRIPTION
I don't know what their problem is right now but even pacman installing opencv won't make the error go away. Don't know either why it went through before without installing gavl but anyway: the more the better according to this:

https://www.dyne.org/software/frei0r/