### PR TITLE
gnutls: use tarball instead of git

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -289,7 +289,7 @@ fi
 _check=(libgnutls.{,l}a gnutls.pc)
 if enabled_any gnutls librtmp || [[ $rtmpdump = y ]] || [[ $curl = gnutls ]] &&
     ! files_exist "${_check[@]}" &&
-    do_wget -r -h bb9acab8af2ac430edf45faaaa4ed2c51f86e57cb57689be6701aceef4732ca7 \
+    do_wget -h bb9acab8af2ac430edf45faaaa4ed2c51f86e57cb57689be6701aceef4732ca7 \
     "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-3.6.6.tar.xz"; then
         do_pacman_install nettle
         do_uninstall include/gnutls "${_check[@]}"

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -289,7 +289,7 @@ fi
 _check=(libgnutls.{,l}a gnutls.pc)
 if enabled_any gnutls librtmp || [[ $rtmpdump = y ]] || [[ $curl = gnutls ]] &&
     ! files_exist "${_check[@]}" &&
-    do_wget -h bb9acab8af2ac430edf45faaaa4ed2c51f86e57cb57689be6701aceef4732ca7 \
+    do_wget -r -h bb9acab8af2ac430edf45faaaa4ed2c51f86e57cb57689be6701aceef4732ca7 \
     "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-3.6.6.tar.xz"; then
         do_pacman_install nettle
         do_uninstall include/gnutls "${_check[@]}"

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -290,8 +290,8 @@ _check=(libgnutls.{,l}a gnutls.pc)
 if enabled_any gnutls librtmp || [[ $rtmpdump = y ]] || [[ $curl = gnutls ]] &&
     ! files_exist "${_check[@]}" &&
     do_wget -h bb9acab8af2ac430edf45faaaa4ed2c51f86e57cb57689be6701aceef4732ca7 \
-	"https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-3.6.6.tar.xz"; then
-	    do_pacman_install nettle
+    "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-3.6.6.tar.xz"; then
+        do_pacman_install nettle
         do_uninstall include/gnutls "${_check[@]}"
         grep_or_sed crypt32 lib/gnutls.pc.in 's/Libs.private.*/& -lcrypt32/'
 		do_separate_confmakeinstall \

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -294,7 +294,7 @@ if enabled_any gnutls librtmp || [[ $rtmpdump = y ]] || [[ $curl = gnutls ]] &&
         do_pacman_install nettle
         do_uninstall include/gnutls "${_check[@]}"
         grep_or_sed crypt32 lib/gnutls.pc.in 's/Libs.private.*/& -lcrypt32/'
-		do_separate_confmakeinstall \
+        do_separate_confmakeinstall \
             --disable-{cxx,doc,tools,tests,nls,rpath,libdane,guile,gcc-warnings} \
             --without-{p11-kit,idn,tpm} --enable-local-libopts \
             --with-included-unistring --disable-code-coverage \

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -288,11 +288,11 @@ if [[ $curl = y ]]; then
 fi
 if enabled_any gnutls librtmp || [[ $rtmpdump = y ]] || [[ $curl = gnutls ]]; then
     _check=(libgnutls.{,l}a gnutls.pc)
-    if do_vcs "https://gitlab.com/gnutls/gnutls.git#tag=gnutls_3_*"; then
+    #if do_vcs "https://gitlab.com/gnutls/gnutls.git#tag=gnutls_3_*"; then
+    if do_vcs "https://gitlab.com/gnutls/gnutls.git#branch=tmp-update-ax-code-coverage"; then
         do_pacman_install nettle
         do_uninstall include/gnutls "${_check[@]}"
         grep_or_sed crypt32 lib/gnutls.pc.in 's/Libs.private.*/& -lcrypt32/'
-        do_patch https://gitlab.com/gnutls/gnutls/merge_requests/905.diff
         log bootstrap ./bootstrap --skip-po
         do_separate_confmakeinstall \
             --disable-{cxx,doc,tools,tests,nls,rpath,libdane,guile,gcc-warnings} \


### PR DESCRIPTION
They started [discussion](https://gitlab.com/gnutls/gnutls/merge_requests/905) again and someone requested to bring code coverage up-to-date now instead of working around it. So the previous patch cannot be applied to the 3.x stable tree, and master doesn't work yet for us here either because we are running on the latest autoconf. So using this branch is currently the only way to build gnutls successfully. We can switch later back to stable or master as you wish. I've been using master for several months now without any problems BTW, just saying. :+1: 