### PR TITLE
Compile: Add SVT-HEVC

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1227,7 +1227,7 @@ _check=(SvtHevcEnc.pc libSvtHevcEnc.dll.a svt-hevc/EbApi.h
 if [[ $svthevc = "y" ]] && do_vcs "https://github.com/OpenVisualCloud/SVT-HEVC.git"; then
     do_uninstall bin-video/SVT-Hevc/libSvtHevcEnc.dll.a "${_check[@]}"
     do_patch "https://github.com/OpenVisualCloud/SVT-HEVC/pull/213.patch"
-    do_patch "http://0x0.st/zQKB.patch"
+    do_patch "http://0x0.st/zQP4.patch"
     do_patch "https://github.com/OpenVisualCloud/SVT-HEVC/pull/206.patch"
     do_cmakeinstall video -DUNIX=OFF
     do_checkIfExist

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -61,6 +61,7 @@ while true; do
 --avs2=* ) avs2="${1#*=}"; shift ;;
 --timeStamp=* ) timeStamp="${1#*=}"; shift ;;
 --noMintty=* ) noMintty="${1#*=}"; set >"$LOCALBUILDDIR/old.var"; shift ;;
+--svthevc=* ) svthevc="${1#*=}"; shift ;;
     -- ) shift; break ;;
     -* ) echo "Error, unknown option: '$1'."; exit 1 ;;
     * ) break ;;
@@ -1218,6 +1219,17 @@ if [[ $mp4box = "y" ]] && do_vcs "https://github.com/gpac/gpac.git"; then
     do_make
     log "install" make install-lib
     do_install bin/gcc/MP4Box.exe bin-video/
+    do_checkIfExist
+fi
+
+_check=(SvtHevcEnc.pc libSvtHevcEnc.dll.a svt-hevc/EbApi.h
+    bin-video/Svt-Hevc/{libSvtHevcEnc.dll,SvtHevcEncApp.exe})
+if [[ $svthevc = "y" ]] && do_vcs "https://github.com/OpenVisualCloud/SVT-HEVC.git"; then
+    do_uninstall bin-video/SVT-Hevc/libSvtHevcEnc.dll.a "${_check[@]}"
+    do_patch "https://github.com/OpenVisualCloud/SVT-HEVC/pull/213.patch"
+    do_patch "http://0x0.st/zQKB.patch"
+    do_patch "https://github.com/OpenVisualCloud/SVT-HEVC/pull/206.patch"
+    do_cmakeinstall video -DUNIX=OFF
     do_checkIfExist
 fi
 

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -113,7 +113,7 @@ pdf-build libmpv-shared
 set iniOptions=msys2Arch arch license2 vpx2 x2643 x2652 other265 flac fdkaac mediainfo ^
 soxB ffmpegB2 ffmpegUpdate ffmpegChoice mp4box rtmpdump mplayer2 mpv cores deleteSource ^
 strip pack logging bmx standalone updateSuite aom faac ffmbc curl cyanrip2 redshift rav1e ^
-ripgrep dav1d vvc jq dssim avs2 timeStamp noMintty
+ripgrep dav1d vvc jq dssim avs2 timeStamp noMintty svthevc
 
 set previousOptions=0
 set msys2ArchINI=0
@@ -412,6 +412,29 @@ if %buildother265%==1 set "other265=y"
 if %buildother265%==2 set "other265=n"
 if %buildother265% GTR 2 GOTO other265
 if %deleteINI%==1 echo.other265=^%buildother265%>>%ini%
+
+:svthevc
+if %svthevcINI%==0 (
+    echo -------------------------------------------------------------------------------
+    echo -------------------------------------------------------------------------------
+    echo.
+    echo. Build SVT-Hevc? [H.265 encoder]
+    echo. 1 = Yes
+    echo. 2 = No
+    echo.
+    echo. Note: Requires at least an Intel fourth generation core or AMD Zen to
+    echo. run.
+    echo.
+    echo -------------------------------------------------------------------------------
+    echo -------------------------------------------------------------------------------
+    set /P buildsvthevc="Build SVT-Hevc: "
+) else set buildsvthevc=%svthevcINI%
+
+if "%buildsvthevc%"=="" GOTO svthevc
+if %buildsvthevc%==1 set "svthevc=y"
+if %buildsvthevc%==2 set "svthevc=n"
+if %buildsvthevc% GTR 2 GOTO svthevc
+if %deleteINI%==1 echo.svthevc=^%buildsvthevc%>>%ini%
 
 :vvc
 if %vvcINI%==0 (
@@ -1561,7 +1584,7 @@ set compileArgs=--cpuCount=%cpuCount% --build32=%build32% --build64=%build64% ^
 --logging=%logging% --bmx=%bmx% --standalone=%standalone% --aom=%aom% --faac=%faac% --ffmbc=%ffmbc% ^
 --curl=%curl% --cyanrip=%cyanrip% --redshift=%redshift% --rav1e=%rav1e% --ripgrep=%ripgrep% ^
 --dav1d=%dav1d% --vvc=%vvc% --jq=%jq% --dssim=%dssim% --avs2=%avs2% --timeStamp=%timeStamp% ^
---noMintty=%noMintty%
+--noMintty=%noMintty% --svthevc=%svthevc%
     set "msys2=%msys2%"
     set "noMintty=%noMintty%"
     if %build64%==yes ( set "MSYSTEM=MINGW64" ) else set "MSYSTEM=MINGW32"


### PR DESCRIPTION
I tried this outside of the suite, and it worked with these flags, however I would like someone else to test if it will compile properly, preferable with an older cpu. Reason why is that it sets -march=native in the cmake list and although it can be patched out, it does not change that compiling requires some extensions not present in x86_64. It seems it requires at least sse4.1 (gcc's nehalem, Intel first gen core or gcc's bdver1, AMD Bulldozer(I haven't tested on an AMD cpu yet because all of my AMD cpus are in use in linux boxes))

I does not seem that the BUILD_SHARED_LIBS=off actually do anything atm as it is hard coded .so right now. There is a pr to make it so that it can be turned off.

If I can confirm that this works, I can work on #1103 to integrate with x265.