### PR TITLE
fontconfig: update to 2.13.1

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -227,7 +227,7 @@ if [[ "$mplayer" = "y" ]] || ! mpv_disabled libass ||
         if enabled libxml2; then
             do_pacman_install libxml2
             sed -i 's|Cflags:|& -DLIBXML_STATIC|' fontconfig.pc.in
-			extracommands+=(--enable-libxml2)
+            extracommands+=(--enable-libxml2)
         fi
         CFLAGS+=" $(enabled libxml2 && echo -DLIBXML_STATIC)"
         do_separate_confmakeinstall global "${extracommands[@]}"

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -211,7 +211,7 @@ if [[ "$mplayer" = "y" ]] || ! mpv_disabled libass ||
     [[ $ffmpeg = "sharedlibs" ]] && enabled_any {lib,}fontconfig &&
         do_removeOption "--enable-(lib|)fontconfig"
     if enabled_any {lib,}fontconfig &&
-        do_vcs "https://anongit.freedesktop.org/git/fontconfig.git#tag=2.13.1"; then
+        do_vcs "https://gitlab.freedesktop.org/fontconfig/fontconfig.git#tag=2.13.1"; then
         do_uninstall include/fontconfig "${_check[@]}"
         sed -i 's| test$||' Makefile.am
         sed -i 's|Libs.private:|& -lintl|' fontconfig.pc.in


### PR DESCRIPTION
For a successful quick test (this will simply burn-in the current timestamp into the video with a Standard Windows font) one can run:
`ffmpeg -y -report:level=debug -i input.mp4 -vf drawtext=fontsize=24:fontcolor=yellow:x=(w-text_w)/2:y=(h-text_h)-16:fontfile='C\:\\Windows\\Fonts\\Verdana.ttf':text="TimeStamp\\:%{pts\\:hms}":box=1:boxcolor=red:boxborderw=8 -c:v h264 -c:a copy output.mp4`