### PR TITLE
tesseract: fix linking with ffmpeg

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -459,8 +459,7 @@ if [[ $ffmpeg != "no" || $standalone = y ]] && enabled libtesseract; then
         _check+=(bin-global/tesseract.exe)
         do_uninstall include/tesseract "${_check[@]}"
         sed -i -e 's|Libs.private.*|& -lstdc++|' \
-               -e 's|Libs.private.*|& -larchive -lnettle -lregex -lexpat -llzma|' \
-               -e 's|Libs.private.*|& -lzstd -llz4 -lbz2 -lz -lbcrypt -liconv|' tesseract.pc.in
+               -e 's|Requires.private.*|& libarchive iconv|' tesseract.pc.in
         do_separate_confmakeinstall global --disable-{graphics,tessdata-prefix} \
             LIBLEPT_HEADERSDIR="$LOCALDESTDIR/include" \
             LIBS="$($PKG_CONFIG --libs iconv lept libtiff-4)" --datadir="$LOCALDESTDIR/bin-global"

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -454,11 +454,13 @@ if [[ $ffmpeg != "no" || $standalone = y ]] && enabled libtesseract; then
 
     _check=(libtesseract.{,l}a tesseract.pc)
     if do_vcs "https://github.com/tesseract-ocr/tesseract.git"; then
-        do_pacman_install docbook-xsl
+        do_pacman_install docbook-xsl nettle
         do_autogen
         _check+=(bin-global/tesseract.exe)
         do_uninstall include/tesseract "${_check[@]}"
-        sed -i "s|Libs.private.*|& -lstdc++|" tesseract.pc.in
+        sed -i -e 's|Libs.private.*|& -lstdc++|' \
+               -e 's|Libs.private.*|& -larchive -lnettle -lregex -lexpat -llzma|' \
+               -e 's|Libs.private.*|& -lzstd -llz4 -lbz2 -lz -lbcrypt -liconv|' tesseract.pc.in
         do_separate_confmakeinstall global --disable-{graphics,tessdata-prefix} \
             LIBLEPT_HEADERSDIR="$LOCALDESTDIR/include" \
             LIBS="$($PKG_CONFIG --libs iconv lept libtiff-4)" --datadir="$LOCALDESTDIR/bin-global"


### PR DESCRIPTION
Reason for all this: https://github.com/tesseract-ocr/tesseract/commit/1c7e00611b5a6b0e2d2094f0a1326ff3c3e1fd98

Do you see any libs apart from nettle not installed with the base or should it be OK like this?