### PR TITLE
tesseract: pacman install libarchive

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -454,7 +454,7 @@ if [[ $ffmpeg != "no" || $standalone = y ]] && enabled libtesseract; then
 
     _check=(libtesseract.{,l}a tesseract.pc)
     if do_vcs "https://github.com/tesseract-ocr/tesseract.git"; then
-        do_pacman_install docbook-xsl nettle
+        do_pacman_install docbook-xsl nettle libarchive
         do_autogen
         _check+=(bin-global/tesseract.exe)
         do_uninstall include/tesseract "${_check[@]}"

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -454,7 +454,7 @@ if [[ $ffmpeg != "no" || $standalone = y ]] && enabled libtesseract; then
 
     _check=(libtesseract.{,l}a tesseract.pc)
     if do_vcs "https://github.com/tesseract-ocr/tesseract.git"; then
-        do_pacman_install docbook-xsl nettle libarchive
+        do_pacman_install docbook-xsl libarchive
         do_autogen
         _check+=(bin-global/tesseract.exe)
         do_uninstall include/tesseract "${_check[@]}"


### PR DESCRIPTION
I'm looking into msys2 for 32bit right now again and as I see only now that libarchive was installed if mpv is enabled/=2 . So we need to install it here as well as otherwise it would produce an error if someone didn't include mpv.