### PR TITLE
gpac: add --extra-libs=-llzma

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1234,7 +1234,7 @@ if [[ $mp4box = "y" ]] && do_vcs "https://github.com/gpac/gpac.git"; then
     do_uninstall include/gpac "${_check[@]}"
     git grep -PIl "\xC2\xA0" | xargs -r sed -i 's/\xC2\xA0/ /g'
     LDFLAGS+=" -L$LOCALDESTDIR/lib -L$MINGW_PREFIX/lib" \
-        do_separate_conf --static-mp4box
+        do_separate_conf --static-mp4box --extra-libs=-llzma
     do_make
     log "install" make install-lib
     do_install bin/gcc/MP4Box.exe bin-video/


### PR DESCRIPTION
Adds --extra-libs=-llzma to line 1237 in order to compile gpac successfully. Otherwise it complains with several undefined references. Should fix #1134 .