### PR TITLE
Batch: Add a catch if running 32-bit cmd under 64-bit OS. closes #1141

### DIFF
--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -121,9 +121,8 @@ if exist %ini% GOTO checkINI
 :selectmsys2Arch
 set deleteIni=1
 
-if %PROCESSOR_ARCHITECTURE%==x86 (
-    IF NOT DEFINED PROCESSOR_ARCHITEW6432 set msys2Arch=1
-) else set msys2Arch=2
+if %PROCESSOR_ARCHITECTURE%==x86 if NOT DEFINED PROCESSOR_ARCHITEW6432 set msys2Arch=1
+if NOT DEFINED msys2Arch set msys2Arch=2
 
 echo.[compiler list]>%ini%
 echo.msys2Arch=^%msys2Arch%>>%ini%


### PR DESCRIPTION
This should make it so that even if running a 32-bit cmd within a 64-bit cmd, msys2 will be 64-bit.