### PR TITLE
Fix the color background

### DIFF
--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -21,7 +21,7 @@
 ::-----------------------------------------------------------------------------
 
 @echo off
-color 80
+color 70
 title media-autobuild_suite
 
 setlocal


### PR DESCRIPTION
When chaging the background color some remote clients fail with the "dark gray" background (they set it as "black" background). So change it to "light gray".

Read about color range here: http://smallvoid.com/article/winnt-command-prompt-color.html

You can check the difference in a CONSOLE using "color 70" and "color 80".
