### PR TITLE
Patches: add verbosity to notifying use of patches

### DIFF
--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -1654,7 +1654,7 @@ create_winpty_exe() {
     [[ -f "${installdir}/${exename}"_exe ]] && mv "${installdir}/${exename}"{_,.}exe
 }
 
-_define(){ IFS='\n' read -r -d '' ${1} || true; }
+_define(){ IFS=$'\n' read -r -d '' ${1} || true; }
 create_ab_pkgconfig() {
     # from https://stackoverflow.com/a/8088167
     local script_file

--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -1840,6 +1840,7 @@ check_custom_patches(){
    if [ -d $LOCALBUILDDIR ] && [ -f $LOCALBUILDDIR/${vcsFolder}_extra.sh ]; then
         export REPO_DIR="$LOCALBUILDDIR/${_basedir}"
         export REPO_NAME="${vcsFolder}"
+        do_print_progress "Found ${vcsFolder}_extra.sh. Sourcing script"
         source $LOCALBUILDDIR/${vcsFolder}_extra.sh
         echo "${vcsFolder}" >> $LOCALBUILDDIR/patchedFolders
         sort -uo $LOCALBUILDDIR/patchedFolders{,}
@@ -1851,7 +1852,10 @@ extra_script(){
     local commandname="$2"
     if type _${stage}_${commandname} >/dev/null 2>&1; then
         pushd "${REPO_DIR}" >/dev/null
-        log "${stage}_${commandname}" _${stage}_${commandname}
+        local vcsFolder="${REPO_DIR%-*}"
+        vcsFolder="${vcsFolder#*build/}"
+        do_print_progress "Running ${stage} ${commandname} from ${vcsFolder}_extra.sh"
+        log quiet "${stage}_${commandname}" _${stage}_${commandname}
         popd >/dev/null
     fi
 }


### PR DESCRIPTION
Also fix(?) IFS not separating on newline. 
<https://github.com/koalaman/shellcheck/wiki/SC2141>
It seems with `IFS='\n'` will match `\` or `n` and not newline

It seems that the output is the same regardless, although the second lacks an extra newline at the end of the file