### PR TITLE
Repository links

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -674,7 +674,7 @@ fi
 
 if [[ $ffmpeg != "no" ]] && enabled libsoxr; then
     _check=(soxr.h libsoxr.a)
-    if do_vcs https://notabug.org/RiCON/soxr.git libsoxr; then
+    if do_vcs "https://gitlab.com/media-autobuild_suite-dependencies/libsoxr.git"; then
         do_uninstall "${_check[@]}"
         do_cmakeinstall -DWITH_LSR_BINDINGS=off -DBUILD_TESTS=off -DWITH_OPENMP=off
         do_checkIfExist
@@ -1174,7 +1174,7 @@ fi
 
 _check=(DeckLinkAPI.h DeckLinkAPIVersion.h DeckLinkAPI_i.c)
 if [[ $ffmpeg != "no" ]] && enabled decklink &&
-    do_vcs "https://notabug.org/RiCON/decklink-headers.git"; then
+    do_vcs "https://gitlab.com/media-autobuild_suite-dependencies/decklink-headers.git"; then
     do_makeinstall PREFIX="$LOCALDESTDIR"
     do_checkIfExist
 fi
@@ -2012,7 +2012,7 @@ if [[ $bmx = "y" ]]; then
     do_pacman_install uriparser
 
     _check=(bin-video/MXFDump.exe libMXF-1.0.{{,l}a,pc})
-    if do_vcs https://notabug.org/RiCON/libmxf.git libMXF-1.0; then
+    if do_vcs "https://gitlab.com/media-autobuild_suite-dependencies/libmxf.git" libMXF-1.0; then
         do_autogen
         do_uninstall include/libMXF-1.0 "${_check[@]}"
         do_separate_confmakeinstall video --disable-examples
@@ -2021,7 +2021,7 @@ if [[ $bmx = "y" ]]; then
 
     _check=(libMXF++-1.0.{{,l}a,pc})
     _deps=(libMXF-1.0.a)
-    if do_vcs https://notabug.org/RiCON/libmxfpp.git libMXF++-1.0; then
+    if do_vcs "https://gitlab.com/media-autobuild_suite-dependencies/libmxfpp.git" libMXF++-1.0; then
         do_autogen
         do_uninstall include/libMXF++-1.0 "${_check[@]}"
         do_separate_confmakeinstall video --disable-examples
@@ -2030,7 +2030,7 @@ if [[ $bmx = "y" ]]; then
 
     _check=(bin-video/{bmxtranswrap,{h264,mov,vc2}dump,mxf2raw,raw2bmx}.exe)
     _deps=("$MINGW_PREFIX"/lib/liburiparser.a lib{MXF{,++}-1.0,curl}.a)
-    if do_vcs https://notabug.org/RiCON/bmx.git; then
+    if do_vcs "https://gitlab.com/media-autobuild_suite-dependencies/bmx.git"; then
         do_autogen
         do_uninstall libbmx-0.1.{{,l}a,pc} bin-video/bmxparse.exe \
             include/bmx-0.1 "${_check[@]}"

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1829,7 +1829,7 @@ if [[ $mpv != "n" ]] && pc_exists libavcodec libavformat libswscale libavfilter;
 
     _check=(mujs.h libmujs.a)
     if ! mpv_disabled javascript &&
-        do_vcs http://git.ghostscript.com/user/tor/mujs.git; then
+        do_vcs "https://github.com/ccxvii/mujs.git"; then
         do_uninstall bin-global/mujs.exe "${_check[@]}"
         log clean make clean
         do_make install-static prefix="$LOCALDESTDIR" bindir="$LOCALDESTDIR/bin-global"

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1549,7 +1549,7 @@ fi
 
 _check=(bin-video/vvc/{Encoder,Decoder}App.exe)
 if [[ $vvc = y ]] &&
-    do_vcs "https://vcgit.hhi.fraunhofer.de/jvet/VVCSoftware_VTM.git" vvc; then
+    do_vcs "https://gitlab.com/media-autobuild_suite-dependencies/VVCSoftware_VTM.git" vvc; then
     do_uninstall bin-video/vvc
     # patch for easier install of apps
     # probably not of upstream's interest because of how experimental the codec is

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1522,7 +1522,7 @@ unset vsprefix
 _check=(liblensfun.a lensfun.pc lensfun/lensfun.h)
 if [[ $ffmpeg != "no" ]] && enabled liblensfun &&
     do_pkgConfig "lensfun = 0.3.95.0" &&
-    do_vcs "git://git.code.sf.net/p/lensfun/code#tag=v0.3.95" lensfun; then
+    do_vcs "https://github.com/lensfun/lensfun.git"; then
     do_pacman_install glib2
     grep_or_sed liconv "$MINGW_PREFIX/lib/pkgconfig/glib-2.0.pc" 's;-lintl;& -liconv;g'
     grep_or_sed Libs.private libs/lensfun/lensfun.pc.cmake '/Libs:/ a\Libs.private: -lstdc++'

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1214,7 +1214,7 @@ if [[ $x264 != no ]]; then
     _check=(x264{,_config}.h libx264.a x264.pc)
     [[ $standalone = y ]] && _check+=(bin-video/x264.exe)
     _bitdepth="$(get_api_version x264_config.h BIT_DEPTH)"
-    if do_vcs "https://git.videolan.org/git/x264.git" ||
+    if do_vcs "https://code.videolan.org/videolan/x264.git" ||
         [[ $x264 = o8   && "$_bitdepth" =~ (0|10) ]] ||
         [[ $x264 = high && "$_bitdepth" =~ (0|8) ]] ||
         [[ $x264 =~ (yes|full|shared|fullv) && "$_bitdepth" != 0 ]]; then

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -840,7 +840,7 @@ _check=(librtmp.{a,pc})
 [[ $rtmpdump = y || $standalone = y ]] && _check+=(bin-video/rtmpdump.exe)
 if { [[ $rtmpdump = "y" ]] ||
     { [[ $ffmpeg != "no" ]] && enabled librtmp; }; } &&
-    do_vcs "http://repo.or.cz/rtmpdump.git" librtmp; then
+    do_vcs "https://gitlab.com/media-autobuild_suite-dependencies/rtmpdump.git" librtmp; then
     [[ $rtmpdump = y || $standalone = y ]] && _check+=(bin-video/rtmp{suck,srv,gw}.exe)
     do_uninstall include/librtmp "${_check[@]}"
     [[ -f "librtmp/librtmp.a" ]] && log "clean" make clean

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1089,7 +1089,7 @@ fi
 if [[ $mediainfo = "y" ]]; then
     [[ $curl = openssl ]] && hide_libressl
     _check=(libzen.{a,pc})
-    if do_vcs "https://github.com/MediaArea/ZenLib" libzen; then
+    if do_vcs "https://github.com/MediaArea/ZenLib.git" libzen; then
         do_uninstall include/ZenLib bin-global/libzen-config \
             "${_check[@]}" libzen.la lib/cmake/zenlib
         do_cmakeinstall Project/CMake
@@ -1099,7 +1099,7 @@ if [[ $mediainfo = "y" ]]; then
 
     _check=(libmediainfo.{a,pc})
     _deps=(lib{zen,curl}.a)
-    if do_vcs "https://github.com/MediaArea/MediaInfoLib" libmediainfo; then
+    if do_vcs "https://github.com/MediaArea/MediaInfoLib.git" libmediainfo; then
         do_uninstall include/MediaInfo{,DLL} bin-global/libmediainfo-config \
             "${_check[@]}" libmediainfo.la lib/cmake/mediainfolib
         do_cmakeinstall Project/CMake -DBUILD_ZLIB=off -DBUILD_ZENLIB=off
@@ -1876,7 +1876,7 @@ if [[ $mpv != "n" ]] && pc_exists libavcodec libavformat libswscale libavfilter;
 
     _check=(shaderc/shaderc.h libshaderc_combined.a)
     if ! mpv_disabled shaderc &&
-        do_vcs "https://github.com/google/shaderc"; then
+        do_vcs "https://github.com/google/shaderc.git"; then
         do_uninstall "${_check[@]}" include/shaderc include/libshaderc_util
 
         function add_third_party() {
@@ -1912,7 +1912,7 @@ if [[ $mpv != "n" ]] && pc_exists libavcodec libavformat libswscale libavfilter;
 
     _check=(crossc.{h,pc} libcrossc.a)
     if ! mpv_disabled crossc &&
-        do_vcs "https://github.com/rossy/crossc"; then
+        do_vcs "https://github.com/rossy/crossc.git"; then
         do_uninstall "${_check[@]}"
         log submodule git submodule update --init
         log clean make clean

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -163,7 +163,7 @@ fi
 
 _check=(bin-global/rg.exe)
 if [[ $ripgrep = y ]] &&
-    do_vcs "https://github.com/BurntSushi/ripgrep.git#tag=0.*"; then
+    do_vcs "https://github.com/BurntSushi/ripgrep.git"; then
     do_uninstall "${_check[@]}"
     do_rust --features 'pcre2'
     do_install "target/$CARCH-pc-windows-gnu/release/rg.exe" bin-global/

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -492,7 +492,7 @@ fi
 _check=(librubberband.a rubberband.pc rubberband/{rubberband-c,RubberBandStretcher}.h)
 if { { [[ $ffmpeg != "no" ]] && enabled librubberband; } ||
     ! mpv_disabled rubberband; } && do_pkgConfig "rubberband = 1.8.1" &&
-    do_vcs https://github.com/lachs0r/rubberband.git; then
+    do_vcs "https://github.com/lachs0r/rubberband.git"; then
     do_uninstall "${_check[@]}"
     log "distclean" make distclean
     do_make PREFIX="$LOCALDESTDIR" install-static
@@ -644,7 +644,7 @@ if [[ $standalone = y ]] && enabled libopus; then
     _deps=(opus.pc "$MINGW_PREFIX"/lib/pkgconfig/{libssl,ogg}.pc)
     if do_vcs "https://git.xiph.org/opusfile.git"; then
         do_uninstall "${_check[@]}"
-        do_patch https://0x0.st/sgwa.txt
+        do_patch "https://0x0.st/sgwa.txt"
         do_autogen
         do_separate_confmakeinstall --disable-{examples,doc}
         do_checkIfExist
@@ -1153,7 +1153,7 @@ fi
 
 if [[ $ffmpeg != "no" ]] && enabled_any frei0r ladspa; then
     _check=(libdl.a dlfcn.h)
-    if do_vcs https://github.com/dlfcn-win32/dlfcn-win32.git; then
+    if do_vcs "https://github.com/dlfcn-win32/dlfcn-win32.git"; then
         do_uninstall "${_check[@]}"
         [[ -f config.mak ]] && log clean make distclean
         sed -i 's|__declspec(dllexport)||g' dlfcn.h
@@ -1163,7 +1163,7 @@ if [[ $ffmpeg != "no" ]] && enabled_any frei0r ladspa; then
     fi
 
     _check=(frei0r.{h,pc})
-    if do_vcs https://github.com/dyne/frei0r.git; then
+    if do_vcs "https://github.com/dyne/frei0r.git"; then
         sed -i 's/find_package (Cairo)//' "CMakeLists.txt"
         do_uninstall lib/frei0r-1 "${_check[@]}"
         do_pacman_install gavl
@@ -1261,10 +1261,10 @@ if [[ $x264 != no ]]; then
             unset_extra_script
 
             _check=("$LOCALDESTDIR"/opt/lightffmpeg/lib/pkgconfig/ffms2.pc bin-video/ffmsindex.exe)
-            if do_vcs https://github.com/FFMS/ffms2.git; then
+            if do_vcs "https://github.com/FFMS/ffms2.git"; then
                 do_uninstall "${_check[@]}"
                 sed -i 's/Libs.private.*/& -lstdc++/;s/Cflags.*/& -DFFMS_STATIC/' ffms2.pc.in
-                do_patch https://0x0.st/sgEY.txt
+                do_patch "https://0x0.st/sgEY.txt"
                 mkdir -p src/config
                 do_autoreconf
                 do_separate_confmakeinstall video --prefix="$LOCALDESTDIR/opt/lightffmpeg"
@@ -1685,7 +1685,7 @@ if [[ $ffmpeg != "no" ]]; then
 
         if [[ ${#FFMPEG_OPTS[@]} -gt 25 ]]; then
             # remove redundant -L and -l flags from extralibs
-            do_patch ffmpeg-0001-configure-fix-failures-with-long-command-lines.patch
+            do_patch "ffmpeg-0001-configure-fix-failures-with-long-command-lines.patch"
         fi
 
         # shared
@@ -2118,7 +2118,7 @@ if [[ $cyanrip = y ]]; then
 fi
 
 _check=(bin-video/ffmbc.exe)
-if [[ $ffmbc = y ]] && do_vcs https://github.com/bcoudurier/FFmbc.git; then
+if [[ $ffmbc = y ]] && do_vcs "https://github.com/bcoudurier/FFmbc.git"; then
     _notrequired=yes
     create_build_dir
     log configure ../configure --target-os=mingw32 --enable-gpl \
@@ -2128,7 +2128,7 @@ if [[ $ffmbc = y ]] && do_vcs https://github.com/bcoudurier/FFmbc.git; then
 fi
 
 _check=(bin-global/redshift.exe)
-if [[ $redshift = y ]] && do_vcs https://github.com/jonls/redshift.git; then
+if [[ $redshift = y ]] && do_vcs "https://github.com/jonls/redshift.git"; then
     [[ -f configure ]] || log bootstrap ./bootstrap
     do_separate_confmakeinstall global --enable-wingdi \
         --disable-{nls,ubuntu,corelocation,quartz,drm,randr,vidmode,geoclue2,gui}

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -538,7 +538,7 @@ enabled libspeex && do_pacman_install speex
 _check=(bin-audio/speex{enc,dec}.exe)
 if [[ $standalone = y ]] && enabled libspeex && ! { files_exist "${_check[@]}" &&
     grep -q '1.2.0' "$LOCALDESTDIR/bin-audio/speexenc.exe"; } &&
-    do_vcs "https://git.xiph.org/speex.git"; then
+    do_vcs "https://github.com/xiph/speex.git"; then
     do_uninstall include/speex libspeex.{l,}a speex.pc "${_check[@]}"
     do_autoreconf
     do_separate_conf --enable-vorbis-psy --enable-binaries
@@ -550,7 +550,7 @@ fi
 
 _check=(libFLAC{,++}.{,l}a flac{,++}.pc)
 [[ $standalone = y ]] && _check+=(bin-audio/flac.exe)
-if [[ $flac = y ]] && do_vcs "https://git.xiph.org/flac.git"; then
+if [[ $flac = y ]] && do_vcs "https://github.com/xiph/flac.git"; then
     do_pacman_install libogg
     do_autogen
     if [[ $standalone = y ]]; then
@@ -612,7 +612,7 @@ fi
 _check=(bin-audio/oggenc.exe)
 _deps=("$MINGW_PREFIX"/lib/libvorbis.a)
 if [[ $standalone = y ]] && enabled libvorbis && ! files_exist "${_check[@]}" &&
-    do_vcs "https://git.xiph.org/vorbis-tools.git" vorbis-tools; then
+    do_vcs "https://github.com/xiph/vorbis-tools.git"; then
     _check+=(bin-audio/oggdec.exe)
     do_autoreconf
     do_uninstall "${_check[@]}"
@@ -628,7 +628,7 @@ fi
 unset _deps
 
 _check=(libopus.{,l}a opus.pc opus/opus.h)
-if enabled libopus && do_vcs "https://git.xiph.org/opus.git"; then
+if enabled libopus && do_vcs "https://github.com/xiph/opus.git"; then
     do_pacman_remove opus
     do_uninstall include/opus "${_check[@]}"
     do_autogen
@@ -642,7 +642,7 @@ if [[ $standalone = y ]] && enabled libopus; then
     hide_libressl
     _check=(opus/opusfile.h libopus{file,url}.{,l}a opus{file,url}.pc)
     _deps=(opus.pc "$MINGW_PREFIX"/lib/pkgconfig/{libssl,ogg}.pc)
-    if do_vcs "https://git.xiph.org/opusfile.git"; then
+    if do_vcs "https://github.com/xiph/opusfile.git"; then
         do_uninstall "${_check[@]}"
         do_patch "https://0x0.st/sgwa.txt"
         do_autogen
@@ -652,7 +652,7 @@ if [[ $standalone = y ]] && enabled libopus; then
 
     _check=(opus/opusenc.h libopusenc.{pc,{,l}a})
     _deps=(opus.pc)
-    if do_vcs "https://git.xiph.org/libopusenc.git"; then
+    if do_vcs "https://github.com/xiph/libopusenc.git"; then
         do_uninstall "${_check[@]}"
         do_autogen
         do_separate_confmakeinstall --disable-{examples,doc}
@@ -661,7 +661,7 @@ if [[ $standalone = y ]] && enabled libopus; then
 
     _check=(bin-audio/opusenc.exe)
     _deps=(opusfile.pc libopusenc.pc)
-    if do_vcs "https://git.xiph.org/opus-tools.git"; then
+    if do_vcs "https://github.com/xiph/opus-tools.git"; then
         _check+=(bin-audio/opus{dec,info}.exe)
         do_uninstall "${_check[@]}"
         do_autogen


### PR DESCRIPTION
- Switch to using github/gitlab mirrors for most non-cdn supported repositories (xiph, etc)
- Unbind ripgrep since there is now 11.0.1
- Switch to github ffmpeg mirrors
- Switch to videolan's new gitlab based code.videolan.org links
- Formatting: Add quotes around repo links and patch links
- Use hourly gitlab mirrors for notabug repos, or.cz, and fraunhofer's
  - Mainly because my win10 vm does not want to properly pull from notabug and because I want to pull reliance off of dedicated servers and into major cdns.
    - doing regular git clone and do_vcs outside of script works but inside script says connection timed out with 0b transferred

I think that I might see if I can do automatic fallback for repos to <https://gitlab.com/media-autobuild_suite-dependencies> in do_vcs in case the original link stops failing for odd reasons.

(I really wish that github and other major git providers had a proper mirroring repos functionality [github needs access to the server's .git folder])