### PR TITLE
zip_logs: Add no_logs flag to disable zipping and uploading logs

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -71,7 +71,8 @@ if [[ $noMintty = y ]]; then ( set -o posix ; set )>"$LOCALBUILDDIR/old.var"; fi
 
 source "$LOCALBUILDDIR"/media-suite_helper.sh
 
-echo -e "${orange}Warning: We will not accept any issues lacking any form of logs or logs.zip! ${reset}"
+[[ -f "$LOCALBUILDDIR/no_logs" ||  $logging = n ]]
+    && echo -e "${orange}Warning: We will not accept any issues lacking any form of logs or logs.zip!${reset}"
 
 buildProcess() {
 set_title

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -71,6 +71,8 @@ if [[ $noMintty = y ]]; then ( set -o posix ; set )>"$LOCALBUILDDIR/old.var"; fi
 
 source "$LOCALBUILDDIR"/media-suite_helper.sh
 
+echo -e "${orange}Warning: We will not accept any issues lacking any form of logs or logs.zip! ${reset}"
+
 buildProcess() {
 set_title
 echo -e "\n\t${orange}Starting $bits compilation of all tools${reset}"

--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -1181,7 +1181,7 @@ zip_logs() {
     files+=($(find . -maxdepth 1 -name "*.stripped.log" -o -name "*_options.txt" -o -name "media-suite_*.sh" \
         -o -name "last_run" -o -name "media-autobuild_suite.ini" -o -name "diagnostics.txt" -o -name "patchedFolders"))
     7za -mx=9 a logs.zip "${files[@]}" >/dev/null
-    [[ $build32 || $build64 ]] && url="$(/usr/bin/curl -sF'file=@logs.zip' https://0x0.st)"
+    [[ ! -f "$LOCALBUILDDIR/no_logs" ]] && [[ $build32 || $build64 ]] && url="$(/usr/bin/curl -sF'file=@logs.zip' https://0x0.st)"
     popd >/dev/null
     echo
     if [[ $url ]]; then


### PR DESCRIPTION
Closes #1182 

To disable uploading logs to 0x0, add `touch "$LOCALBUILDDIR/no_logs"` to *_extra.sh

This disables uploading logs globally regardless of the package failing to compile.
(@wiiaboo should this be changed to upload if the local package has no modification?)

There is nothing to remove the flag so if log uploading is desired, remove the flag by hand.