### PR TITLE
compile: fix regression caused by #1190. Fixes #1193

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -71,8 +71,8 @@ if [[ $noMintty = y ]]; then ( set -o posix ; set )>"$LOCALBUILDDIR/old.var"; fi
 
 source "$LOCALBUILDDIR"/media-suite_helper.sh
 
-[[ -f "$LOCALBUILDDIR/no_logs" ||  $logging = n ]]
-    && echo -e "${orange}Warning: We will not accept any issues lacking any form of logs or logs.zip!${reset}"
+[[ -f "$LOCALBUILDDIR/no_logs" ||  $logging = n ]] &&
+    echo -e "${orange}Warning: We will not accept any issues lacking any form of logs or logs.zip!${reset}"
 
 buildProcess() {
 set_title


### PR DESCRIPTION
I am assuming that this fixes #1193 as when I switched noMintty off, the mintty terminal with compile.sh opened, but then immediately closed. I don't know why it worked with noMintty on.