### PR TITLE
noMintty: change how script fails and reads vars

### DIFF
--- a/build/bash.ps1
+++ b/build/bash.ps1
@@ -20,16 +20,14 @@ try {
     if (Test-Path "$build\compilation_failed") {
         Write-Transcript
         $compilefail = Get-Content -Path $build\compilation_failed
-        $env:reason = $compilefail[1]
-        $env:operation = $compilefail[2]
         New-Item -Force -ItemType File -Path "$build\fail_comp" -Value $(
-            "while read line; do declare -x `"`$line`"; done < /build/fail.var`n" +
             "source /build/media-suite_helper.sh`n" +
+            "source /build/fail.var`n" +
             "cd `$(head -n 1 /build/compilation_failed)`n" +
             "if [[ `$logging = y ]]; then`n" +
-            "echo `"Likely error:`"`n" +
-            "tail `"ab-suite.`${operation}.log`"`n" +
-            "echo `"`${red}`$reason failed. Check `$(pwd -W)/ab-suite.`$operation.log`${reset}`"`n" +
+            "   echo `"Likely error:`"`n" +
+            "   tail `"ab-suite.$($compilefail[2]).log`"`n" +
+            "   echo `"`${red}$($compilefail[1]) failed. Check `$(pwd -W)/ab-suite.$($compilefail[2]).log`${reset}`"`n" +
             "fi`n" +
             "echo `"`${red}This is required for other packages, so this script will exit.`${reset}`"`n" +
             "zip_logs`n" +

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -60,14 +60,12 @@ while true; do
 --dssim=* ) dssim="${1#*=}"; shift ;;
 --avs2=* ) avs2="${1#*=}"; shift ;;
 --timeStamp=* ) timeStamp="${1#*=}"; shift ;;
---noMintty=* ) noMintty="${1#*=}"; shift ;;
+--noMintty=* ) noMintty="${1#*=}"; set >"$LOCALBUILDDIR/old.var"; shift ;;
     -- ) shift; break ;;
     -* ) echo "Error, unknown option: '$1'."; exit 1 ;;
     * ) break ;;
   esac
 done
-
-if [[ $noMintty = y ]]; then ( set -o posix ; set )>"$LOCALBUILDDIR/old.var"; fi
 
 source "$LOCALBUILDDIR"/media-suite_helper.sh
 

--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -1137,9 +1137,8 @@ compilation_fail() {
         return 1
     else
         if [[ $noMintty = y ]]; then
-            diff <(cat $LOCALBUILDDIR/old.var) <(set -o posix ; set) | grep '^[<>]' | sed -nr 's/> (.*)/\1/p' > "$LOCALBUILDDIR/fail.var"
-            echo "$PWD" > "$LOCALBUILDDIR/compilation_failed"
-            echo -e "$reason\n$operation" >> "$LOCALBUILDDIR/compilation_failed"
+            diff "$LOCALBUILDDIR/old.var" <(set) | grep '^[<>]' | sed -nr 's/> (.*)/\1/p' > "$LOCALBUILDDIR/fail.var"
+            echo -e "$PWD\n$reason\n$operation" > "$LOCALBUILDDIR/compilation_failed"
             exit
         else
             if [[ $logging = y ]]; then


### PR DESCRIPTION
Might hopefully fix not valid identifier errors when a compile fails with noMintty