### PR TITLE
upx: update to 3.95

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -133,9 +133,9 @@ set_title "compiling global tools"
 echo -e "\n\t${orange}Starting $bits compilation of global tools${reset}"
 
 if [[ $packing = y ]] &&
-    ! [[ -e /opt/bin/upx.exe && "$(/opt/bin/upx -V | head -1)" = "upx 3.94" ]] &&
-    do_wget -h 74308db1183436576d011bfcc3e7c99c836fb052de7b7eb0539026366453d6e8 \
-        "https://github.com/upx/upx/releases/download/v3.94/upx394w.zip"; then
+    ! [[ -e /opt/bin/upx.exe && "$(/opt/bin/upx -V | head -1)" = "upx 3.95" ]] &&
+    do_wget -h f94ff30b175d125d1c238458716f5808aee222547a813918b44d0f67035c0054 \
+        "https://github.com/upx/upx/releases/download/v3.95/upx-3.95-win32.zip"; then
     do_install upx.exe /opt/bin/upx.exe
 fi
 


### PR DESCRIPTION
Do we need to worry about a 64bit version of upx?

I'm not entirely sure about this logic down below. It should be
``` bash
if [[ $build64 = y ]]; then
    do_wget -h 5c076f87ba64d82f11513f4af0ceb07246a3540aa3c72ca3ffc2d53971fa56e3 \
        "https://github.com/upx/upx/releases/download/v3.95/upx-3.95-win64.zip"
else
    do_wget -h f94ff30b175d125d1c238458716f5808aee222547a813918b44d0f67035c0054 \
        "https://github.com/upx/upx/releases/download/v3.95/upx-3.95-win32.zip"
fi
```
(haven't used brackets before really.)