### PR TITLE
vswhere: use latests

### DIFF
--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -1505,8 +1505,7 @@ get_cl_path() {
         vswhere=$_suite_vswhere
     else
         pushd "$LOCALBUILDDIR" 2>/dev/null
-        local _ver=2.6.7
-        do_wget -c -r -q "https://github.com/Microsoft/vswhere/releases/download/$_ver/vswhere.exe"
+        do_wget -c -r -q "https://github.com/Microsoft/vswhere/releases/latest/download/vswhere.exe"
         [[ -f vswhere.exe ]] || return 1
         do_install vswhere.exe /opt/bin/
         vswhere=$_suite_vswhere


### PR DESCRIPTION
https://help.github.com/en/articles/linking-to-releases
Since I found out we can link to the latest release.
Although this won't work for repos that hardcodes the version in the filename