### PR TITLE
Github: Use markdown issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,6 +1,0 @@
-If you use the built-in options and it's broken because of a lib you didn't even
-know existed or will never use, please choose your own libs and avoid creating
-issues about it. I barely have any time or will to maintain this.
-
-For new libs and tools pull requests are strongly recommended instead of opening
-a feature request for the same reason above.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: 'Build Bug report'
+about: 'Repo bug report'
+title: '[mingw32|mingw64] [repo]'
+labels: 'Bug Report'
+assignees: ''
+
+---
+<!---
+If you use the built-in options and it's broken because of a lib you didn't even know existed or will never use, please choose your own libs and avoid creating issues about it. I barely have any time or will to maintain this.
+
+For new libs and tools pull requests are strongly recommended instead of opening a feature request for the same reason above.
+
+Make sure to mention if you are building for 32-bit or 64-bit or both and mention what the suite failed to build. Please make sure to at least give the title a little detail as to what you failed to compile.
+
+Any issues without a `logs.zip` or at least an error report with either be ignored or closed without warning. Any issue not dealing with the suite or a custom build will not be supported and should be taken to the proper forums or repo page.
+
+If you understood the above, add the info below:
+--->
+
+``` bash
+Paste output of the suite here
+```
+
+[logs.zip](https://github.com/jb-alvarado/media-autobuild_suite)

--- a/.github/ISSUE_TEMPLATE/generic_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/generic_bug_report.md
@@ -1,0 +1,16 @@
+---
+name: 'Generic/Suite bug report'
+about: 'Generic/Suite bug report'
+title: ''
+labels: 'Bug Report'
+assignees: ''
+
+---
+<!---
+If you use the built-in options and it's broken because of a lib you didn't even
+know existed or will never use, please choose your own libs and avoid creating
+issues about it. I barely have any time or will to maintain this.
+
+For new libs and tools pull requests are strongly recommended instead of opening
+a feature request for the same reason above.
+--->

--- a/.github/ISSUE_TEMPLATE/request.md
+++ b/.github/ISSUE_TEMPLATE/request.md
@@ -1,0 +1,12 @@
+---
+name: 'Feature Request'
+about: 'Feature Request'
+title: 'Request: [Description]'
+labels: 'Feature Request'
+assignees: ''
+
+---
+<!---
+Probably will get ignored if the request is not described well or based on personal feelings (worth the effort or not).\
+If you think that it's worthy to be included into the suite, open a pr instead or /cc @1480c1 instead (maybe)
+--->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+<!--
+Description
+
+(Optional) Fixes #[issueNumber]
+--->

--- a/.github/PULL_REQUEST_TEMPLATE/fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/fix.md
@@ -1,0 +1,13 @@
+---
+name: 'Bug Fix'
+about: 'Bug Fix'
+title: '[file]: Fix [issue]'
+labels: 'Bug Fix'
+assignees: 'wiiaboo'
+
+---
+<!--
+Description
+
+(Optional) Fixes #[issueNumber]
+--->

--- a/.github/PULL_REQUEST_TEMPLATE/new.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new.md
@@ -1,0 +1,9 @@
+---
+name: 'New Package'
+about: 'Add a new package'
+title: '[repo]: Add [repo]'
+labels: 'New Package'
+assignees: 'wiiaboo'
+
+---
+Add [repo] to the suite.

--- a/.github/PULL_REQUEST_TEMPLATE/update.md
+++ b/.github/PULL_REQUEST_TEMPLATE/update.md
@@ -1,0 +1,9 @@
+---
+name: 'Update Package'
+about: 'Update a package'
+title: '[repo]: update to [version]'
+labels: 'Update'
+assignees: 'wiiaboo'
+
+---
+Update [repo] to [version]


### PR DESCRIPTION
Idk about the pr templates since I can't create a pr from a branch on a fork to the master of a fork, but the issue templates seem to work. The PR templates require the files to be in the master branch of the master repo. I can split the commits into individual templates for easy reverting in wanted.

Motivated by the recent lack of issue description in the title and lack of information of 32|64 bit builds etc.

e.g. "Compilation failed", "x265", "libwebp", etc