### PR TITLE
libtiff: force all libtiff tools into bin-global instead of bin

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -413,6 +413,7 @@ if enabled_any libwebp libtesseract &&
     do_uninstall "${_check[@]}"
     grep_or_sed 'Requires.private' libtiff-4.pc.in \
         '/Libs:/ a\Requires.private: libjpeg liblzma zlib libzstd'
+    sed -i 's|CMAKE_INSTALL_FULL_BINDIR}|&/../bin-global|' tools/CMakeLists.txt
     do_cmakeinstall -Dwebp=OFF -DUNIX=OFF
     do_checkIfExist
 fi


### PR DESCRIPTION
`-DCMAKE_INSTALL_FULL_BINDIR="${LOCALDESTDIR}/bin-global"` doesn't work?

And I'm NOT going to some bugzilla site to report or PR this. It's ENOUGH now with github and gitlab and more of them 
(like gitmemory I have just discovered?). I refuse to register to more sites! EVERYTHING all RIGHT here, so don't waste my time!

<!--
Description

(Optional) Fixes #[issueNumber]
--->
