### PR TITLE
bat: export CXX

### DIFF
--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -1626,9 +1626,10 @@ goto :EOF
     echo.PKG_CONFIG_PATH="${LOCALDESTDIR}/lib/pkgconfig:${MINGW_PREFIX}/lib/pkgconfig"
     echo.CPPFLAGS="-D_FORTIFY_SOURCE=2 -D__USE_MINGW_ANSI_STDIO=1"
     echo.CFLAGS="-mthreads -mtune=generic -O2 -pipe"
+    echo.CXX="g++"
     echo.CXXFLAGS="${CFLAGS}"
     echo.LDFLAGS="-pipe -static-libgcc -static-libstdc++"
-    echo.export DXSDK_DIR ACLOCAL_PATH PKG_CONFIG PKG_CONFIG_PATH CPPFLAGS CFLAGS CXXFLAGS LDFLAGS MSYSTEM
+    echo.export DXSDK_DIR ACLOCAL_PATH PKG_CONFIG PKG_CONFIG_PATH CPPFLAGS CFLAGS CXX CXXFLAGS LDFLAGS MSYSTEM
     echo.
     echo.export CARGO_HOME="/opt/cargo" RUSTUP_HOME="/opt/cargo"
     echo.


### PR DESCRIPTION
Weeks ago I had a problem with libplacebo. While running a mingw shell libplacebo compiled just fine but the script errored. Going to the bottom of it revealed it was trying to use cl.exe from orig_path in Windows (which we use here) instead of g++/c++. After trying things like `-DCMAKE_CXX_COMPILER=$(command -v g++.exe)` and or saving and restoring PATHs like `#PATH=${MINGW_PREFIX}/bin:${MSYS2_PATH}`  etc I just made it global (as it is set in some LX distros as well) and never had a problem since then. So I'm PR'ing this now.

<!--
Description

(Optional) Fixes #[issueNumber]
--->
