### PR TITLE
Removed a "fi" that prevented the suite from running

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -917,7 +917,6 @@ if { [[ $aom = y ]] || { [[ $ffmpeg != "no" ]] && enabled libaom; }; } &&
     do_cmakeinstall video -DENABLE_{DOCS,TOOLS,TESTS}=off -DENABLE_NASM=on \
         -DENABLE_TEST{S,DATA}=OFF -DCONFIG_LOWBITDEPTH=1 \
         "${extracommands[@]}"
-    fi
     do_checkIfExist
     unset extracommands
 fi


### PR DESCRIPTION
Line 920 had an extra `fi` that didn't allowed the media-suite from running.

Fixes #1240
