### PR TITLE
helper: split do_cmake into basecmake and cmake

### DIFF
--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -1080,7 +1080,7 @@ do_custom_patches() {
     done
 }
 
-do_cmake() {
+do_basecmake() {
     local bindir=""
     local root=".."
     case "$1" in
@@ -1098,9 +1098,13 @@ do_cmake() {
         return
     log "cmake" cmake "$root" -G Ninja -DBUILD_SHARED_LIBS=off \
         -DCMAKE_TOOLCHAIN_FILE="$LOCALDESTDIR/etc/toolchain.cmake" \
-        -DCMAKE_INSTALL_PREFIX="$LOCALDESTDIR" -DUNIX=on \
+        -DCMAKE_INSTALL_PREFIX="$LOCALDESTDIR" \
         -DCMAKE_BUILD_TYPE=Release $bindir "$@"
     extra_script post cmake
+}
+
+do_cmake() {
+    do_basecmake "$@" -DUNIX=on
 }
 
 do_ninja(){


### PR DESCRIPTION
<!--
Description

(Optional) Fixes #[issueNumber]
--->
Split do_cmake into do_basecmake and do_cmake

Should not affect any existing do_cmake calls.

Allows to cmake without using `-DUNIX=ON`