### PR TITLE
do_cmake: add more variables and switches

### DIFF
--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -1099,8 +1099,9 @@ do_cmake() {
     log "cmake" cmake "$root" -G Ninja -DBUILD_SHARED_LIBS=off \
         -DCMAKE_TOOLCHAIN_FILE="$LOCALDESTDIR/etc/toolchain.cmake" \
         -DCMAKE_INSTALL_PREFIX="$LOCALDESTDIR" -DUNIX=on \
-        -DCMAKE_BUILD_TYPE=Release $bindir "$@"
+        -DCMAKE_BUILD_TYPE=Release $bindir ${cmake_extras[@]} "$@"
     extra_script post cmake
+    unset cmake_extras
 }
 
 do_ninja(){


### PR DESCRIPTION
<!--
Description

(Optional) Fixes #[issueNumber]
--->
Allows for extra_script to add flags for cmake
Allows for option to skip `create_build_dir` or pass a name to `create_build_dir`