### PR TITLE
do_cmake: Dont bind $1 to bindir, fix non-local variable

### DIFF
--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -1092,10 +1092,9 @@ do_cmake() {
         *)
             if [[ -d "./$1" ]]; then
                 [[ -n "$skip_build_dir" ]] && root="./$1" || root="../$1"
-            elif [[ -z "$bindir" ]]; then
-                bindir="$1"
+                shift
             fi
-            shift && break ;;
+            break ;;
         esac
     done
 

--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -1080,7 +1080,7 @@ do_custom_patches() {
 do_cmake() {
     local bindir=""
     local root=".."
-    local cmakebuilddir=""
+    local cmake_build_dir=""
     while (( "$#" )); do
         case "$1" in
         global|audio|video)


### PR DESCRIPTION
Closes #1256

It seems that one of the flags is still being consumed, presumable due to the fact that the flags will be shifted regardless if $1 has been consumed or not