### PR TITLE
Activate libsvthevc for ffmpeg_options_full

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ For information about the compiler environment see the wiki, there you also have
         - librubberband (git snapshot)
         - libsrt (git)
         - libssh (mingw)
+        - libsvthevc (git)
         - libtesseract (git)
         - libvmaf (git)
         - libxavs (svn snapshot)

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -377,6 +377,9 @@ if %x2652INI%==0 (
     echo.
     echo. Binaries being built depends on "standalone=y"
     echo.
+    echo. Note: In order to use the SVT-HEVC-Encoder with x265,
+    echo. it needs to be enabled separately.
+    echo.
     echo -------------------------------------------------------------------------------
     echo -------------------------------------------------------------------------------
     set /P buildx265="Build x265: "
@@ -418,14 +421,15 @@ if %svthevcINI%==0 (
     echo -------------------------------------------------------------------------------
     echo -------------------------------------------------------------------------------
     echo.
-    echo. Build SVT-Hevc? [H.265 encoder]
+    echo. Build SVT-HEVC? [H.265 encoder]
     echo. 1 = Yes
     echo. 2 = No
     echo.
     echo. Note: Requires at least an Intel fourth generation core or AMD Zen to
-    echo. run and only supports 64-bit
-    echo. To add to ffmpeg, add --enable-libsvthevc to ffmpeg_options.txt under
-    echo. the build folder
+    echo. run and only supports 64-bit.
+    echo.
+    echo. Needs to be enabled to use it with x265.
+    echo. Only enabling it for FFmpeg will not include it in x265.
     echo -------------------------------------------------------------------------------
     echo -------------------------------------------------------------------------------
     set /P buildsvthevc="Build SVT-Hevc: "

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -96,7 +96,7 @@ set ffmpeg_options_full=chromaprint cuda-nvcc decklink frei0r libbs2b libcaca ^
 libcdio libfdk-aac libflite libfribidi libgme libgsm libilbc libkvazaar ^
 libmodplug libnpp libopenh264 librtmp librubberband libssh ^
 libtesseract libxavs libzmq libzvbi opencl opengl libvmaf libcodec2 ^
-libsrt ladspa #vapoursynth #liblensfun #libsvthevc
+libsrt ladspa libsvthevc #vapoursynth #liblensfun
 
 :: built-ins
 set mpv_options_builtin=#cplayer #manpage-build #lua #javascript #libass ^

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -432,7 +432,7 @@ if %svthevcINI%==0 (
     echo. Only enabling it for FFmpeg will not include it in x265.
     echo -------------------------------------------------------------------------------
     echo -------------------------------------------------------------------------------
-    set /P buildsvthevc="Build SVT-Hevc: "
+    set /P buildsvthevc="Build SVT-HEVC: "
 ) else set buildsvthevc=%svthevcINI%
 
 if "%buildsvthevc%"=="" GOTO svthevc


### PR DESCRIPTION
Since the building process is running smoothly with libsvthevc activated, why not activate it as default...

<!--
Description

(Optional) Fixes #[issueNumber]
--->
