### PR TITLE
NoMintty: Change how compile.sh fails

### DIFF
--- a/build/bash.ps1
+++ b/build/bash.ps1
@@ -33,7 +33,7 @@ try {
             "zip_logs`n" +
             "echo `"Make sure the suite is up-to-date before reporting an issue. It might've been fixed already.`"`n" +
             "do_prompt `"Try running the build again at a later time.`"") | Out-Null
-        Start-Process -NoNewWindow -Wait -FilePath $bash -ArgumentList ("-l /build/fail_comp").Split(' ')
+        &$bash "-l" "/build/fail_comp"
         Remove-Item -Force -Path $build\compilation_failed, $build\fail_comp
     }
 } catch {

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -60,7 +60,7 @@ while true; do
 --dssim=* ) dssim="${1#*=}"; shift ;;
 --avs2=* ) avs2="${1#*=}"; shift ;;
 --timeStamp=* ) timeStamp="${1#*=}"; shift ;;
---noMintty=* ) noMintty="${1#*=}"; set >"$LOCALBUILDDIR/old.var"; shift ;;
+--noMintty=* ) noMintty="${1#*=}"; [ -f "$LOCALBUILDDIR/fail.var" ] && rm "$LOCALBUILDDIR/fail.var"; (declare -p | grep -vE "BASH|LINES|COLUMNS|CommonProgramFiles") > "$LOCALBUILDDIR/old.var"; shift ;;
 --svthevc=* ) svthevc="${1#*=}"; shift ;;
     -- ) shift; break ;;
     -* ) echo "Error, unknown option: '$1'."; exit 1 ;;
@@ -1562,7 +1562,7 @@ if  { ! mpv_disabled vapoursynth || enabled vapoursynth; }; then
             [vapoursynth-name]=vapoursynth
             [vapoursynth-description]='A frameserver for the 21st century'
             [vapoursynth-cflags]="-DVS_CORE_EXPORTS"
-            
+
             [vsscript-name]=vapoursynth-script
             [vsscript-description]='Library for interfacing VapourSynth with Python'
             [vsscript-private]="-l$_python_lib -lstdc++"

--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -1181,8 +1181,8 @@ compilation_fail() {
         return 1
     else
         if [[ $noMintty = y ]]; then
-            diff "$LOCALBUILDDIR/old.var" <(set) | grep '^[<>]' | sed -nr 's/> (.*)/\1/p' > "$LOCALBUILDDIR/fail.var"
-            echo -e "$PWD\n$reason\n$operation" > "$LOCALBUILDDIR/compilation_failed"
+            diff --changed-group-format='%>' --unchanged-group-format='' "$LOCALBUILDDIR/old.var" <(declare -p | grep -vE "BASH|LINES|COLUMNS|CommonProgramFiles") > "$LOCALBUILDDIR/fail.var"
+            printf '%s\n%s\n%s\n' "$PWD" "$reasons" "$operation" > "$LOCALBUILDDIR/compilation_failed"
             exit
         else
             if [[ $logging = y ]]; then


### PR DESCRIPTION
Using Start-Process caused the cursor to reset to top left

Use declare -p since that doesn't output functions