### PR TITLE
Update: Shellcheck plus rework check packages

### DIFF
--- a/build/media-suite_update.sh
+++ b/build/media-suite_update.sh
@@ -48,7 +48,7 @@ if [[ "$update" = "yes" ]]; then
     echo "-------------------------------------------------------------------------------"
     echo
 
-    if [[ ! -d ../.git ]] && which git > /dev/null; then
+    if [[ ! -d ../.git ]] && command -v git > /dev/null; then
         if ! git clone "https://github.com/jb-alvarado/media-autobuild_suite.git" ab-git; then
             git -C ab-git fetch
         fi
@@ -185,7 +185,7 @@ else
     cd_safe "$(cygpath -w /).."
 fi
 
-if which rustup &> /dev/null; then
+if command -v rustup &> /dev/null; then
     echo "Updating rust..."
     rustup update
 fi

--- a/build/media-suite_update.sh
+++ b/build/media-suite_update.sh
@@ -195,7 +195,7 @@ fi
 # packet msys2 system
 # --------------------------------------------------
 
-have_updates="$(pacman -Qu|grep -v ignored]$|awk '{print $1}')"
+have_updates="$(pacman -Qu | grep -v ignored]$ | cut -d' ' -f1)"
 if [[ -n $have_updates ]]; then
     echo "-------------------------------------------------------------------------------"
     echo "Updating msys2 system and installed packages..."

--- a/build/media-suite_update.sh
+++ b/build/media-suite_update.sh
@@ -41,7 +41,7 @@ fi
 # update suite
 # --------------------------------------------------
 
-if [[ "$update" = "yes" ]]; then
+if [[ $update == "yes" ]]; then
     echo
     echo "-------------------------------------------------------------------------------"
     echo "checking if suite has been updated..."
@@ -109,7 +109,8 @@ echo
 pacman -Sy --ask=20 --noconfirm
 pacman -Qqe | grep -q sed && pacman -Qqg base | pacman -D --asdeps - && pacman -D --asexplicit mintty flex > /dev/null
 do_unhide_all_sharedlibs
-if [[ -f /etc/pac-base.pk ]] && [[ -f /etc/pac-mingw.pk ]]; then
+
+if [[ -f /etc/pac-base.pk && -f /etc/pac-mingw.pk ]]; then
     echo
     echo "-------------------------------------------------------------------------------"
     echo "Checking pacman packages..."
@@ -125,7 +126,7 @@ if [[ -f /etc/pac-base.pk ]] && [[ -f /etc/pac-mingw.pk ]]; then
     install=$(echo "$diff" | sed -nr 's/> (.*)/\1/p')
     uninstall=$(echo "$diff" | sed -nr 's/< (.*)/\1/p')
 
-    if [[ ! -z "$uninstall" ]]; then
+    if [[ -n $uninstall ]]; then
         echo
         echo "-------------------------------------------------------------------------------"
         echo "You have more packages than needed!"
@@ -154,7 +155,7 @@ if [[ -f /etc/pac-base.pk ]] && [[ -f /etc/pac-mingw.pk ]]; then
             esac
         done
     fi
-    if [[ ! -z "$install" ]]; then
+    if [[ -n $install ]]; then
         echo
         echo "-------------------------------------------------------------------------------"
         echo "You're missing some packages!"
@@ -195,7 +196,7 @@ fi
 # --------------------------------------------------
 
 have_updates="$(pacman -Qu|grep -v ignored]$|awk '{print $1}')"
-if [[ -n "$have_updates" ]]; then
+if [[ -n $have_updates ]]; then
     echo "-------------------------------------------------------------------------------"
     echo "Updating msys2 system and installed packages..."
     echo "-------------------------------------------------------------------------------"

--- a/build/media-suite_update.sh
+++ b/build/media-suite_update.sh
@@ -27,6 +27,8 @@ while true; do
     esac
 done
 
+[[ "$(uname)" == *6.1* ]] && nargs="-n 4"
+
 # start suite update
 if [[ -d "/trunk/build" ]]; then
     cd "/trunk/build" || exit 1

--- a/build/media-suite_update.sh
+++ b/build/media-suite_update.sh
@@ -166,13 +166,14 @@ if [[ -f /etc/pac-base.pk && -f /etc/pac-mingw.pk ]]; then
         while true; do
             read -r -p "install packs [y/n]? " yn
             case $yn in
-                [Yy]* )
-                    echo $install | xargs $nargs pacman -Sw --noconfirm --ask 20 --needed
-                    echo $install | xargs $nargs pacman -S --noconfirm --ask 20 --needed
-                    pacman -D --asexplicit $install
-                    break;;
-                [Nn]* ) exit;;
-                * ) echo "Please answer yes or no";;
+            [Yy]*)
+                xargs $nargs pacman -Sw --noconfirm --ask 20 --needed <<< "$install"
+                xargs $nargs pacman -S --noconfirm --ask 20 --needed <<< "$install"
+                pacman -D --asexplicit $install
+                break
+                ;;
+            [Nn]*) exit ;;
+            *) echo "Please answer yes or no" ;;
             esac
         done
     fi

--- a/build/media-suite_update.sh
+++ b/build/media-suite_update.sh
@@ -200,11 +200,11 @@ if [[ -n $have_updates ]]; then
     echo "-------------------------------------------------------------------------------"
     echo "Updating msys2 system and installed packages..."
     echo "-------------------------------------------------------------------------------"
-    echo "$have_updates" | /usr/bin/grep -Eq '^(pacman|bash|msys2-runtime)$' &&
-        touch build/update_core &&
-        have_updates="$(echo "$have_updates" | /usr/bin/grep -Ev '^(pacman|bash|msys2-runtime)$')"
-    echo $have_updates | xargs $nargs pacman -S --noconfirm --ask 20 \
-        --overwrite "/mingw64/*" --overwrite "/mingw32/*" --overwrite "/usr/*"
+    /usr/bin/grep -Eq '^(pacman|bash|msys2-runtime)$' <<< "$have_updates" &&
+        touch /build/update_core &&
+        have_updates="$(/usr/bin/grep -Ev '^(pacman|bash|msys2-runtime)$' <<< "$have_updates")"
+    xargs $nargs pacman -S --noconfirm --ask 20 --overwrite "/mingw64/*" \
+        --overwrite "/mingw32/*" --overwrite "/usr/*" <<< "$have_updates"
 fi
 
 [[ ! -s /usr/ssl/certs/ca-bundle.crt ]] &&

--- a/build/media-suite_update.sh
+++ b/build/media-suite_update.sh
@@ -81,8 +81,8 @@ fi # end suite update
 # packet update system
 # --------------------------------------------------
 
-/usr/bin/pacman-key -f EFD16019AE4FF531 >/dev/null || pacman-key -r EFD16019AE4FF531 >/dev/null
-/usr/bin/pacman-key --list-sigs AE4FF531 | grep -q pacman@localhost || pacman-key --lsign AE4FF531 >/dev/null
+{ /usr/bin/pacman-key -f EFD16019AE4FF531 || pacman-key -r EFD16019AE4FF531; } > /dev/null
+{ /usr/bin/pacman-key --list-sigs AE4FF531 | grep -q pacman@localhost || pacman-key --lsign AE4FF531; } > /dev/null
 
 #always kill gpg-agent
 ps|grep gpg-agent|awk '{print $1}'|xargs -r kill -9
@@ -107,7 +107,7 @@ echo "--------------------------------------------------------------------------
 echo
 
 pacman -Sy --ask=20 --noconfirm
-pacman -Qqe | grep -q sed && pacman -Qqg base | pacman -D --asdeps - && pacman -D --asexplicit mintty flex > /dev/null
+{ pacman -Qqe | grep -q sed && pacman -Qqg base | pacman -D --asdeps - && pacman -D --asexplicit mintty flex; } > /dev/null
 do_unhide_all_sharedlibs
 
 if [[ -f /etc/pac-base.pk && -f /etc/pac-mingw.pk ]]; then

--- a/build/media-suite_update.sh
+++ b/build/media-suite_update.sh
@@ -88,17 +88,16 @@ fi # end suite update
 gpgconf --kill gpg-agent
 
 # for some people the signature is broken
-printf 'Server = %s\nSigLevel = Optional\n' \
-    'https://i.fsbn.eu/abrepo/' > /etc/pacman.d/abrepo.conf
+/usr/bin/grep -q Optional /etc/pacman.d/abrepo.conf ||
+    printf 'Server = %s\nSigLevel = Optional\n' \
+        'https://i.fsbn.eu/abrepo/' > /etc/pacman.d/abrepo.conf
 
 # fix fuckup
 grep -q 'i.fsbn.eu/abrepo' /etc/pacman.conf &&
     sed -i '/\[abrepo\]/,+2d' /etc/pacman.conf
 
 /usr/bin/grep -q abrepo /etc/pacman.conf ||
-    sed -i '/\[mingw32\]/ i\[abrepo]\
-Include = /etc/pacman.d/abrepo.conf\
-' /etc/pacman.conf
+    sed -i '/\[mingw32\]/ i\[abrepo]\nInclude = /etc/pacman.d/abrepo.conf\n' /etc/pacman.conf
 
 echo
 echo "-------------------------------------------------------------------------------"

--- a/build/media-suite_update.sh
+++ b/build/media-suite_update.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2086
 
 while true; do
   case $1 in

--- a/build/media-suite_update.sh
+++ b/build/media-suite_update.sh
@@ -56,7 +56,7 @@ if [[ $update == "yes" ]]; then
     fi
     cd_safe ..
     if [[ -d .git ]]; then
-        if [[ -n $(git status --short --untracked-files=no) ]]; then
+        if [[ -n "$(git diff --name-only)" ]]; then
             diffname="$(date +%F-%H.%M.%S)"
             git diff --diff-filter=M >> "build/user-changes-${diffname}.diff"
             echo "Your changes have been exported to build/user-changes-${diffname}.diff."

--- a/build/media-suite_update.sh
+++ b/build/media-suite_update.sh
@@ -85,7 +85,7 @@ fi # end suite update
 { /usr/bin/pacman-key --list-sigs AE4FF531 | grep -q pacman@localhost || pacman-key --lsign AE4FF531; } > /dev/null
 
 #always kill gpg-agent
-ps|grep gpg-agent|awk '{print $1}'|xargs -r kill -9
+gpgconf --kill gpg-agent
 
 # for some people the signature is broken
 printf 'Server = %s\nSigLevel = Optional\n' \


### PR DESCRIPTION
To be considered before #1305, split off from #1303

Would the confirmation for missing packages really be necessary? Logically speaking, since we have marked those packages as necessary for building certain tools and codecs, wouldn't they be considered a necessary/installed later on either way?

I have also included to use shfmt this time, (caused the case spread and indention, removal of quotes from the tests, and double equal for the tests) I can remove it if it seems unnecessary