### PR TITLE
do_getFFmpegConfig: strip no length options

### DIFF
--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -937,20 +937,24 @@ disabled_all() {
 }
 
 do_getMpvConfig() {
+    local MPV_TEMP_OPTS=()
     MPV_OPTS=()
     if [[ -f "/trunk/media-autobuild_suite.bat" && "$ffmpegChoice" =~ (n|z|f) ]]; then
         IFS=$'\r\n' read -d '' -r -a bat < /trunk/media-autobuild_suite.bat
-        mapfile -t MPV_OPTS < <(do_readbatoptions "mpv_options_(builtin|basic)")
+        mapfile -t MPV_TEMP_OPTS < <(do_readbatoptions "mpv_options_(builtin|basic)")
         local option
         [[ $ffmpegChoice = f ]] && while read -r option; do
-            MPV_OPTS+=("$option")
+            [[ -n "$option" ]] && MPV_TEMP_OPTS+=("$option")
         done < <(do_readbatoptions "mpv_options_full")
         echo "Imported default mpv options from .bat"
     else
-        IFS=$'\n' read -d '' -r -a MPV_OPTS < <(do_readoptionsfile "$LOCALBUILDDIR/mpv_options.txt")
+        IFS=$'\n' read -d '' -r -a MPV_TEMP_OPTS < <(do_readoptionsfile "$LOCALBUILDDIR/mpv_options.txt")
     fi
-    do_removeOption MPV_OPTS \
+    do_removeOption MPV_TEMP_OPTS \
         "--(en|dis)able-(vapoursynth-lazy|libguess|static-build|enable-gpl3|egl-angle-lib|encoding|crossc)"
+    for opt in "${MPV_TEMP_OPTS[@]}"; do
+        [[ -n "$opt" ]] && MPV_OPTS+=("$opt")
+    done
 }
 
 mpv_enabled() {

--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -732,8 +732,15 @@ do_getFFmpegConfig() {
                 <(do_readoptionsfile "$LOCALBUILDDIR/ffmpeg_options_shared.txt")
         fi
     fi
+
+    for opt in "${FFMPEG_BASE_OPTS[@]}"; do
+        [[ -n "$opt" ]] && FFMPEG_OPTS+=("$opt")
+    done
+    for opt in "${FFMPEG_DEFAULT_OPTS[@]}"; do
+        [[ -n "$opt" ]] && FFMPEG_OPTS+=("$opt")
+    done
+
     echo "License: $license"
-    FFMPEG_OPTS=("${FFMPEG_BASE_OPTS[@]}" "${FFMPEG_DEFAULT_OPTS[@]}")
 
     # we set these accordingly for static or shared
     do_removeOption "--(en|dis)able-(shared|static)"

--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -733,10 +733,7 @@ do_getFFmpegConfig() {
         fi
     fi
 
-    for opt in "${FFMPEG_BASE_OPTS[@]}"; do
-        [[ -n "$opt" ]] && FFMPEG_OPTS+=("$opt")
-    done
-    for opt in "${FFMPEG_DEFAULT_OPTS[@]}"; do
+    for opt in "${FFMPEG_BASE_OPTS[@]}" "${FFMPEG_DEFAULT_OPTS[@]}"; do
         [[ -n "$opt" ]] && FFMPEG_OPTS+=("$opt")
     done
 

--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -878,8 +878,10 @@ do_changeFFmpegConfig() {
 
     # remove libs that don't work with shared
     if [[ $ffmpeg =~ "shared" || $ffmpeg =~ "both" ]]; then
-        FFMPEG_OPTS_SHARED=("${FFMPEG_OPTS[@]}")
-        [[ -v FFMPEG_DEFAULT_OPTS_SHARED ]] && FFMPEG_OPTS_SHARED+=("${FFMPEG_DEFAULT_OPTS_SHARED[@]}")
+        FFMPEG_OPTS_SHARED=()
+        for opt in "${FFMPEG_OPTS[@]}" "${FFMPEG_DEFAULT_OPTS_SHARED[@]}"; do
+            [[ -n "$opt" ]] && FFMPEG_OPTS_SHARED+=("$opt")
+        done
     fi
     if [[ $ffmpeg = "bothstatic" ]]; then
         do_removeOption "--enable-(opencl|opengl|cuda-nvcc|libnpp|libopenh264)"


### PR DESCRIPTION
experienced the same thing as https://github.com/jb-alvarado/media-autobuild_suite/issues/1339
found out that there was an extra `""` appended to the `FFMPEG_DEFAULT_OPTS`