### PR TITLE
VVC: Set ENABLE_SPLIT_PARALLELISM to OFF

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1655,7 +1655,7 @@ if [[ $vvc = y ]] &&
     _notrequired="true"
     # install to own dir because the binaries' names are too generic
     do_cmakeinstall -DCMAKE_INSTALL_BINDIR="$LOCALDESTDIR"/bin-video/vvc \
-        -DBUILD_STATIC=on -DSET_ENABLE_SPLIT_PARALLELISM=ON -DENABLE_SPLIT_PARALLELISM=ON
+        -DBUILD_STATIC=on -DSET_ENABLE_SPLIT_PARALLELISM=ON -DENABLE_SPLIT_PARALLELISM=OFF
     do_checkIfExist
     unset _notrequired
 fi


### PR DESCRIPTION
Temporarily Fixes #1362 

The issue in upstream is that the code that runs when `ENABLE_SPLIT_PARALLISM=ON` is currently broken. By setting  `ENABLE_SPLIT_PARALLISM=OFF`, VVC compiles successfully in the suite.

Once the issue has been solved in upstream, this can be set back to `ON`.