### PR TITLE
Update gnutls 3.6.13 --> 3.6.16

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -334,9 +334,9 @@ if [[ $curl = y ]]; then
 fi
 _check=(libgnutls.{,l}a gnutls.pc)
 if enabled_any gnutls librtmp || [[ $rtmpdump = y || $curl = gnutls ]] &&
-    do_pkgConfig "gnutls = 3.6.13" &&
-    do_wget -h 32041df447d9f4644570cf573c9f60358e865637d69b7e59d1159b7240b52f38 \
-    "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-3.6.13.tar.xz"; then
+    do_pkgConfig "gnutls = 3.6.16" &&
+    do_wget -h 1b79b381ac283d8b054368b335c408fedcb9b7144e0c07f531e3537d4328f3b3 \
+    "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-3.6.16.tar.xz"; then
         do_pacman_install nettle
         do_uninstall include/gnutls "${_check[@]}"
         grep_or_sed crypt32 lib/gnutls.pc.in 's/Libs.private.*/& -lcrypt32/'


### PR DESCRIPTION
Including serious security fixes in 3.6.14. See also https://lists.gnupg.org/pipermail/gnutls-help/2020-June/004648.html

<!--
Description

(Optional) Fixes #[issueNumber]
--->
