### PR TITLE
suite: add av1an

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ For information about the compiler environment see the wiki, there you also have
 
 - other tools
     - aom (git)
+    - av1an (git)
     - bmx (git)
     - curl (git) with WinSSL/LibreSSL/OpenSSL/mbedTLS/GnuTLS backend
     - cyanrip (git)

--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -57,6 +57,7 @@ while true; do
     --dav1d=* ) dav1d=${1#*=} && shift ;;
     --libavif=* ) libavif=${1#*=} && shift ;;
     --jpegxl=* ) jpegxl=${1#*=} && shift ;;
+    --av1an=* ) av1an=${1#*=} && shift ;;
     --vvc=* ) vvc=${1#*=} && shift ;;
     --uvg266=* ) uvg266=${1#*=} && shift ;;
     --vvenc=* ) vvenc=${1#*=} && shift ;;
@@ -167,6 +168,17 @@ $CC -E -P -include pthread.h - < /dev/null | grep -q MemoryBarrier ||
 
 set_title "compiling global tools"
 do_simple_print -p '\n\t'"${orange}Starting $bits compilation of global tools${reset}"
+
+if [[ $bits = 32bit && $av1an != n ]]; then
+    do_simple_print "${orange}Av1an cannot be compiled due to Vapoursynth being broken on 32-bit and will be disabled"'!'"${reset}"
+    av1an=n
+    _reenable_av1an=y # so that av1an can be built if both 32 bit and 64 bit targets are enabled
+fi
+
+if [[ $bits = 64bit && $_reenable_av1an = y ]]; then
+    av1an=y
+    unset _reenable_av1an
+fi
 
 if [[ $packing = y &&
     ! "$(/opt/bin/upx -V 2> /dev/null | head -1)" = "upx 4.2.2" ]] &&
@@ -1070,11 +1082,11 @@ if { [[ $rtmpdump = y ]] ||
 fi
 
 _check=(libvpx.a vpx.pc)
-[[ $standalone = y ]] && _check+=(bin-video/vpxenc.exe)
+[[ $standalone = y || $av1an != n ]] && _check+=(bin-video/vpxenc.exe)
 if { enabled libvpx || [[ $vpx = y ]]; } && do_vcs "$SOURCE_REPO_VPX" vpx; then
     extracommands=()
     [[ -f config.mk ]] && log "distclean" make distclean
-    [[ $standalone = y ]] && _check+=(bin-video/vpxdec.exe) ||
+    [[ $standalone = y || $av1an != n ]] && _check+=(bin-video/vpxdec.exe) ||
         extracommands+=(--disable-{examples,webm-io,libyuv,postproc})
     do_uninstall include/vpx "${_check[@]}"
     create_build_dir
@@ -1087,7 +1099,7 @@ if { enabled libvpx || [[ $vpx = y ]]; } && do_vcs "$SOURCE_REPO_VPX" vpx; then
     sed -i 's;HAVE_GNU_STRIP=yes;HAVE_GNU_STRIP=no;' -- ./*.mk
     do_make
     do_makeinstall
-    [[ $standalone = y ]] && do_install vpx{enc,dec}.exe bin-video/
+    [[ $standalone = y || $av1an != n ]] && do_install vpx{enc,dec}.exe bin-video/
     do_checkIfExist
     unset extracommands
 else
@@ -1107,7 +1119,7 @@ fi
 file_installed -s libvmaf.dll.a && rm "$(file_installed libvmaf.dll.a)"
 
 _check=(libaom.a aom.pc)
-if [[ $aom = y || $standalone = y ]]; then
+if [[ $aom = y || $standalone = y || $av1an != n ]]; then
     _aom_bins=true
     _check+=(bin-video/aomenc.exe)
 else
@@ -1147,8 +1159,8 @@ fi
 { enabled librav1e || [[ $libavif = y ]] || [[ $dovitool = y ]]; } && do_pacman_install cargo-c
 
 _check=()
-{ [[ $rav1e = y ]] ||
-    enabled librav1e && [[ $standalone = y ]]; } &&
+{ [[ $rav1e = y ]] || [[ $av1an != n ]] ||
+    { enabled librav1e && [[ $standalone = y ]]; } } &&
     _check+=(bin-video/rav1e.exe)
 { enabled librav1e || [[ $libavif = y ]]; } && _check+=(librav1e.a rav1e.pc rav1e/rav1e.h)
 if { [[ $rav1e = y ]] || [[ $libavif = y ]] || enabled librav1e; } &&
@@ -1169,7 +1181,7 @@ if { [[ $rav1e = y ]] || [[ $libavif = y ]] || enabled librav1e; } &&
     unset _libgit2_pc
 
     # standalone binary
-    if [[ $rav1e = y || $standalone = y ]]; then
+    if [[ $rav1e = y || $standalone = y || $av1an != n ]]; then
         do_rust --profile release-no-lto
         find "target/$CARCH-pc-windows-gnu" -name "rav1e.exe" | while read -r f; do
             do_install "$f" bin-video/
@@ -1601,7 +1613,7 @@ fi
 if [[ $x264 != no ]] ||
     { [[ $ffmpeg != no ]] && enabled libx264; }; then
     _check=(x264{,_config}.h libx264.a x264.pc)
-    [[ $standalone = y ]] && _check+=(bin-video/x264.exe)
+    [[ $standalone = y || $av1an != n ]] && _check+=(bin-video/x264.exe)
     _bitdepth=$(get_api_version x264_config.h BIT_DEPTH)
     if do_vcs "$SOURCE_REPO_X264" ||
         [[ $x264 = o8   && $_bitdepth =~ (0|10) ]] ||
@@ -1615,7 +1627,7 @@ if [[ $x264 != no ]] ||
         old_PKG_CONFIG_PATH=$PKG_CONFIG_PATH
         PKG_CONFIG_PATH=$LOCALDESTDIR/opt/lightffmpeg/lib/pkgconfig:$MINGW_PREFIX/lib/pkgconfig
         unset_extra_script
-        if [[ $standalone = y && $x264 =~ (full|fullv) ]]; then
+        if [[ $standalone = y || $av1an != n ]] && [[ $x264 =~ (full|fullv) ]]; then
             _check=("$LOCALDESTDIR"/opt/lightffmpeg/lib/pkgconfig/libav{codec,format}.pc)
             do_vcs "$ffmpegPath"
             do_uninstall "$LOCALDESTDIR"/opt/lightffmpeg
@@ -1659,7 +1671,7 @@ if [[ $x264 != no ]] ||
             extracommands+=(--disable-lavf --disable-ffms)
         fi
 
-        if [[ $standalone = y ]]; then
+        if [[ $standalone = y || $av1an != n ]]; then
             _check=("$LOCALDESTDIR/opt/lightffmpeg/lib/pkgconfig/liblsmash.pc")
             if do_vcs "$SOURCE_REPO_LIBLSMASH" liblsmash; then
                 [[ -f config.mak ]] && log "distclean" make distclean
@@ -1675,7 +1687,7 @@ if [[ $x264 != no ]] ||
         fi
 
         _check=(x264{,_config}.h x264.pc)
-        [[ $standalone = y ]] && _check+=(bin-video/x264.exe)
+        [[ $standalone = y || $av1an != n ]] && _check+=(bin-video/x264.exe)
         [[ -f config.h ]] && log "distclean" make distclean
 
         x264_build=$(grep ' X264_BUILD ' x264.h | cut -d' ' -f3)
@@ -1712,7 +1724,7 @@ else
 fi
 
 _check=(x265{,_config}.h libx265.a x265.pc)
-[[ $standalone = y ]] && _check+=(bin-video/x265.exe)
+[[ $standalone = y || $av1an != n ]] && _check+=(bin-video/x265.exe)
 if [[ ! $x265 = n ]] && do_vcs "$SOURCE_REPO_X265"; then
     grep_and_sed CMAKE_CXX_IMPLICIT_LINK_LIBRARIES source/CMakeLists.txt 's|\$\{CMAKE_CXX_IMPLICIT_LINK_LIBRARIES\}||g'
     do_uninstall libx265{_main10,_main12}.a bin-video/libx265_main{10,12}.dll "${_check[@]}"
@@ -1735,7 +1747,7 @@ if [[ ! $x265 = n ]] && do_vcs "$SOURCE_REPO_X265"; then
         extra_script post cmake
         do_ninja
     }
-    [[ $standalone = y ]] && cli=-DENABLE_CLI=ON
+    [[ $standalone = y || $av1an != n ]] && cli=-DENABLE_CLI=ON
 
     if [[ $x265 =~ (o12|s|d|y) ]]; then
         cd_safe "$build_root/12bit"
@@ -1786,7 +1798,7 @@ EOF
     }
     build_x265
     cpuCount=1 log "install" ninja install
-    if [[ $standalone = y && $x265 = d ]]; then
+    if [[ $standalone = y || $av1an != n ]] && [[ $x265 = d ]]; then
         cd_safe "$(get_first_subdir -f)"
         do_uninstall bin-video/x265-numa.exe
         do_print_progress "Building NUMA version of binary"
@@ -1859,9 +1871,9 @@ _vapoursynth_install() {
         do_simple_print "${orange}Vapoursynth is known to be broken on 32-bit and will be disabled"'!'"${reset}"
         return 1
     fi
-    _python_ver=3.12.3
+    _python_ver=3.12.6
     _python_lib=python312
-    _vsver=69
+    _vsver=70
     _check=("lib$_python_lib.a")
     if files_exist "${_check[@]}"; then
         do_print_status "python $_python_ver" "$green" "Up-to-date"
@@ -1919,9 +1931,58 @@ _vapoursynth_install() {
     unset _file _python_lib _python_ver _vsver _pc_vars
     return 0
 }
-if ! { { ! mpv_disabled vapoursynth || enabled vapoursynth; } && _vapoursynth_install; }; then
+if ! { { ! mpv_disabled vapoursynth || enabled vapoursynth || [[ $av1an != n ]]; } && _vapoursynth_install; }; then
     mpv_disable vapoursynth
     do_removeOption --enable-vapoursynth
+fi
+
+if [[ $av1an != n ]]; then
+    local av1an_bindir="bin-video"
+    local av1an_ffmpeg_prefix="opt/av1anffmpeg"
+    [[ $av1an = shared ]] && av1an_bindir="bin-video/av1an/bin" && av1an_ffmpeg_prefix="bin-video/av1an"
+
+    _check=("$LOCALDESTDIR"/"$av1an_ffmpeg_prefix"/lib/pkgconfig/lib{av{codec,device,filter,format,util},swscale}.pc)
+    if flavor=av1an do_vcs "$ffmpegPath"; then
+        do_uninstall "$LOCALDESTDIR"/"$av1an_ffmpeg_prefix"
+        [[ -f config.mak ]] && log "distclean" make distclean
+        local av1an_ffmpeg_opts=("--enable-static" "--disable-shared")
+        [[ $av1an = shared ]] && av1an_ffmpeg_opts=("--disable-static" "--enable-shared")
+        # compile ffmpeg executable if ffmpeg is disabled so av1an can function
+        if [[ $ffmpeg != no ]]; then
+            av1an_ffmpeg_opts+=("--disable-programs")
+        else
+            # enable filters too so they can be used with av1an
+            av1an_ffmpeg_opts+=("--disable-ffprobe" "--disable-ffplay" "--enable-filters")
+        fi
+        create_build_dir av1an
+        config_path=.. do_configure "${FFMPEG_BASE_OPTS[@]}" \
+            --prefix="$LOCALDESTDIR/$av1an_ffmpeg_prefix" \
+            --disable-autodetect --disable-everything \
+            --disable-{debug,doc,postproc,network} \
+            --enable-{decoders,demuxers,protocols} \
+            "${av1an_ffmpeg_opts[@]}"
+        do_make && do_makeinstall
+        # move static ffmpeg to a reasonable location if ffmpeg is disabled
+        [[ $av1an != shared ]] && [[ $ffmpeg = no ]] && [[ ! -f "$LOCALDESTDIR"/bin-video/ffmpeg.exe ]] &&
+            mv -f "$LOCALDESTDIR"/{"$av1an_ffmpeg_prefix"/bin,bin-video}/ffmpeg.exe
+        files_exist "${_check[@]}" && touch ../"build_successful${bits}_av1an"
+        unset av1an_ffmpeg_opts
+    fi
+
+    old_PKG_CONFIG_PATH=$PKG_CONFIG_PATH
+    PKG_CONFIG_PATH=$LOCALDESTDIR/$av1an_ffmpeg_prefix/lib/pkgconfig:$PKG_CONFIG_PATH
+
+    _check=("$av1an_bindir"/av1an.exe)
+    if do_vcs "$SOURCE_REPO_AV1AN"; then
+        do_uninstall "${_check[@]}"
+        PKG_CONFIG="$LOCALDESTDIR/bin/ab-pkg-config-static.bat" \
+            VAPOURSYNTH_LIB_DIR="$LOCALDESTDIR/lib" do_rust
+        do_install "target/$CARCH-pc-windows-gnu/release/av1an.exe" $av1an_bindir/
+        do_checkIfExist
+    fi
+
+    PKG_CONFIG_PATH=$old_PKG_CONFIG_PATH
+    unset old_PKG_CONFIG_PATH av1an_{bindir,ffmpeg_prefix}
 fi
 
 if [[ $ffmpeg != no ]] && enabled liblensfun; then

--- a/build/media-suite_deps.sh
+++ b/build/media-suite_deps.sh
@@ -4,6 +4,7 @@
 SOURCE_REPO_AMF=https://github.com/GPUOpen-LibrariesAndSDKs/AMF.git
 SOURCE_REPO_ANGLE=https://chromium.googlesource.com/angle/angle
 SOURCE_REPO_ARRIB24=https://github.com/nkoriyama/aribb24.git
+SOURCE_REPO_AV1AN=https://github.com/master-of-zen/Av1an.git
 SOURCE_REPO_AVISYNTH=https://github.com/AviSynth/AviSynthPlus.git
 SOURCE_REPO_CODEC2=https://github.com/drowe67/codec2.git
 SOURCE_REPO_CURL=https://github.com/curl/curl.git

--- a/doc/forcing-recompilations.md
+++ b/doc/forcing-recompilations.md
@@ -171,6 +171,7 @@ To recompile these, delete `<appname>.exe` in corresponding binary directories:
     /bin-video
         aomdec
         aomenc
+        av1an
         avifdec
         avifenc
         bmxtranswrap

--- a/media-autobuild_suite.bat
+++ b/media-autobuild_suite.bat
@@ -147,7 +147,7 @@ set mpv_options_full=dvdnav cdda #egl-angle #html-build ^
 
 set iniOptions=arch license2 vpx2 x2643 x2652 other265 flac fdkaac mediainfo ^
 soxB ffmpegB2 ffmpegUpdate ffmpegChoice mp4box rtmpdump mplayer2 mpv cores deleteSource ^
-strip pack logging bmx standalone updateSuite aom faac exhale ffmbc curl cyanrip2 ^
+strip pack logging bmx standalone updateSuite av1an aom faac exhale ffmbc curl cyanrip2 ^
 rav1e ripgrep dav1d libavif vvc uvg266 jq dssim avs2 dovitool hdr10plustool ^
 timeStamp noMintty ccache svthevc svtav1 svtvp9 xvc jo vlc CC jpegxl vvenc vvdec ffmpegPath
 @rem re-add autouploadlogs if we find some way to upload to github directly instead
@@ -261,6 +261,33 @@ if %buildstandalone%==2 set "standalone=n"
 if %buildstandalone% GTR 2 GOTO standalone
 if %deleteINI%==1 echo.standalone=^%buildstandalone%>>%ini%
 
+:av1an
+if [0]==[%av1anINI%] (
+    echo -------------------------------------------------------------------------------
+    echo -------------------------------------------------------------------------------
+    echo.
+    echo. Build Av1an [Scalable video encoding framework]?
+    echo. 1 = Yes [link with static FFmpeg]
+    echo. 2 = Yes [link with shared FFmpeg]
+    echo. 3 = No
+    echo.
+    echo. Av1an requires an executable of FFmpeg and one of these encoders to function:
+    echo. aom, SVT-AV1, rav1e, vpx, x264, or x265
+    echo. If FFmpeg is built shared, then the Av1an executable will be in a subfolder.
+    echo. (Note: Not available for 32-bit due to Vapoursynth being broken in 32-bit!^)
+    echo.
+    echo -------------------------------------------------------------------------------
+    echo -------------------------------------------------------------------------------
+    set /P buildav1an="Build av1an: "
+) else set buildav1an=%av1anINI%
+
+if "%buildav1an%"=="" GOTO av1an
+if %buildav1an%==1 set "av1an=y"
+if %buildav1an%==2 set "av1an=shared"
+if %buildav1an%==3 set "av1an=n"
+if %buildav1an% GTR 3 GOTO av1an
+if %deleteINI%==1 echo.av1an=^%buildav1an%>>%ini%
+
 :vpx
 if [0]==[%vpx2INI%] (
     echo -------------------------------------------------------------------------------
@@ -270,7 +297,7 @@ if [0]==[%vpx2INI%] (
     echo. 1 = Yes
     echo. 2 = No
     echo.
-    echo. Binaries being built depends on "standalone=y"
+    echo. Binaries being built depends on "standalone/av1an=y" and are always static.
     echo.
     echo -------------------------------------------------------------------------------
     echo -------------------------------------------------------------------------------
@@ -292,7 +319,7 @@ if [0]==[%aomINI%] (
     echo. 1 = Yes
     echo. 2 = No
     echo.
-    echo. Binaries being built depends on "standalone=y"
+    echo. Binaries being built depends on "standalone/av1an=y" and are always static.
     echo.
     echo -------------------------------------------------------------------------------
     echo -------------------------------------------------------------------------------
@@ -313,6 +340,8 @@ if [0]==[%rav1eINI%] (
     echo. Build rav1e [Alternative, faster AV1 standalone encoder]?
     echo. 1 = Yes
     echo. 2 = No
+    echo.
+    echo. Binaries being built depends on "standalone/av1an=y" and are always static.
     echo.
     echo -------------------------------------------------------------------------------
     echo -------------------------------------------------------------------------------
@@ -404,7 +433,7 @@ if [0]==[%x2643INI%] (
     echo. 6 = Same as 4 with video codecs only (can reduce size by ~3MB^)
     echo. 7 = Lib/binary with only 8-bit
     echo.
-    echo. Binaries being built depends on "standalone=y" and are always static.
+    echo. Binaries being built depends on "standalone/av1an=y" and are always static.
     echo.
     echo -------------------------------------------------------------------------------
     echo -------------------------------------------------------------------------------
@@ -436,7 +465,7 @@ if [0]==[%x2652INI%] (
     echo. 6 = Same as 1 with XP support and non-XP compatible x265-numa.exe
     echo. 7 = Lib/binary with Main12 only
     echo.
-    echo. Binaries being built depends on "standalone=y"
+    echo. Binaries being built depends on "standalone/av1an=y" and are always static.
     echo.
     echo -------------------------------------------------------------------------------
     echo -------------------------------------------------------------------------------
@@ -1858,8 +1887,8 @@ set compileArgs=--cpuCount=%cpuCount% --build32=%build32% --build64=%build64% ^
 --ffmbc=%ffmbc% --curl=%curl% --cyanrip=%cyanrip% --rav1e=%rav1e% --ripgrep=%ripgrep% --dav1d=%dav1d% ^
 --vvc=%vvc% --uvg266=%uvg266% --vvenc=%vvenc% --vvdec=%vvdec% --jq=%jq% --jo=%jo% --dssim=%dssim% ^
 --avs2=%avs2% --dovitool=%dovitool% --hdr10plustool=%hdr10plustool% --timeStamp=%timeStamp% ^
---noMintty=%noMintty% --ccache=%ccache% --svthevc=%svthevc% ^
---svtav1=%svtav1% --svtvp9=%svtvp9% --xvc=%xvc% --vlc=%vlc% --libavif=%libavif% --jpegxl=%jpegxl% ^
+--noMintty=%noMintty% --ccache=%ccache% --svthevc=%svthevc% --svtav1=%svtav1% --svtvp9=%svtvp9% ^
+--xvc=%xvc% --vlc=%vlc% --libavif=%libavif% --jpegxl=%jpegxl% --av1an=%av1an% ^
 --ffmpegPath=%ffmpegPath% --exitearly=%MABS_EXIT_EARLY%
     @REM --autouploadlogs=%autouploadlogs%
     set "noMintty=%noMintty%"


### PR DESCRIPTION
Can be built with static ffmpeg or shared ffmpeg. If Av1an is enabled but FFmpeg is disabled, then the suite will additionally compile a minimal FFmpeg executable. Also updates Vapoursynth to R70 and Python to 3.12.6