### PR TITLE
Remove patch to compactify extralibs

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -2375,11 +2375,6 @@ if [[ $ffmpeg != no ]]; then
                 's|__declspec\(__dllimport__\)||g' "$MINGW_PREFIX"/include/gmp.h
         fi
 
-        if [[ ${#FFMPEG_OPTS[@]} -gt 35 ]]; then
-            # remove redundant -L and -l flags from extralibs
-            do_patch "https://raw.githubusercontent.com/m-ab-s/mabs-patches/master/ffmpeg/0001-configure-deduplicate-linking-flags.patch" am
-        fi
-
         _patches=$(git rev-list $ff_base_commit.. --count)
         [[ $_patches -gt 0 ]] &&
             do_addOption "--extra-version=g$(git rev-parse --short $ff_base_commit)+$_patches"


### PR DESCRIPTION
ffmpeg now passes objects list to linker from a file since https://github.com/FFmpeg/FFmpeg/commit/9e857e1f8aeeb655adb9d09bf53add26a27092e2

so this step should no longer be necessary.

<!--
Description

(Optional) Fixes #[issueNumber]
--->
