### PR TITLE
minor fixes for libjxl and mpv

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -2902,8 +2902,8 @@ if [[ $mpv != n ]] && pc_exists libavcodec libavformat libswscale libavfilter; t
 
         # Fix clang vsscript.dll hard requirement, imitate shinchiro's cmake.
         [[ $CC =~ clang ]] && \
-            sed -i "s|-lvsscript|-lvsscript -Wl,-delayload=vsscript.dll|" \
-                "$LOCALDESTDIR"/lib/pkgconfig/vapoursynth-script.pc
+            grep_or_sed "-Wl,-delayload=vsscript.dll" "$LOCALDESTDIR"/lib/pkgconfig/vapoursynth-script.pc \
+                "s|-lvsscript|-lvsscript -Wl,-delayload=vsscript.dll|"
 
         mapfile -t MPV_ARGS < <(mpv_build_args)
         CFLAGS+=" ${mpv_cflags[*]}" LDFLAGS+=" ${mpv_ldflags[*]}" \


### PR DESCRIPTION
openexr provided by msys2 doesn't seem to have static library, so we'll need to build it if we want it.