### PR TITLE
Fix waveaudio in sox on 32 bit

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1103,7 +1103,7 @@ if [[ $sox = y ]]; then
         enabled libvorbis || extracommands+=(--without-oggvorbis)
         hide_conflicting_libs
         sed -i 's|found_libgsm=yes|found_libgsm=no|g' configure
-        do_separate_conf --disable-symlinks LIBS="-L$LOCALDESTDIR/lib ${extralibs[*]}" "${extracommands[@]}"
+        do_separate_conf --disable-symlinks ac_cv_lib_winmm_waveOutOpen=yes LIBS="-L$LOCALDESTDIR/lib ${extralibs[*]}" "${extracommands[@]}"
         do_make
         do_install src/sox.exe bin-audio/
         do_install sox.pc


### PR DESCRIPTION
The configure script doesn't know about waveOutOpen@24 so waveaudio has never been included in 32 bit sox before. Pass a flag to configure so the test succeeds and then it compiles fine.

<!--
Description

(Optional) Fixes #[issueNumber]
--->
