### PR TITLE
Install libid3tag for sox

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -1081,6 +1081,7 @@ _check=(bin-audio/sox.exe sox.pc)
 _deps=(libsndfile.a opus.pc "$MINGW_PREFIX"/lib/libmp3lame.a)
 if [[ $sox = y ]]; then
     do_pacman_install libmad
+    do_pacman_install libid3tag
     extracommands=()
     if enabled libopus; then
         [[ $standalone = y ]] || do_pacman_install opusfile


### PR DESCRIPTION
Sox uses libid3tag to read tags from mp3 files, so install it along with libmad.
Please do not merge this until msys2 creates a static libid3tag package, see this issue:
https://github.com/msys2/MINGW-packages/issues/27587

<!--
Description

(Optional) Fixes #[issueNumber]
--->
