### PR TITLE
Revert "do_meson: try using both"

### DIFF
--- a/build/media-suite_helper.sh
+++ b/build/media-suite_helper.sh
@@ -1391,11 +1391,9 @@ do_meson() {
     extra_script pre meson
     [[ -f "$(get_first_subdir -f)/do_not_reconfigure" ]] &&
         return
-    local default_libs
-    [[ $ffmpeg =~ "both" ]] && default_libs="both" || default_libs="static"
     # shellcheck disable=SC2086
     PKG_CONFIG="pkgconf --static --keep-system-libs --keep-system-cflags" CC=${CC/ccache /}.bat CXX=${CXX/ccache /}.bat \
-        log "meson" meson setup "$root" --default-library="$default_libs" --default-both-libraries=static --buildtype=release \
+        log "meson" meson setup "$root" --default-library=static --default-both-libraries=static --buildtype=release \
         --prefix="$LOCALDESTDIR" --backend=ninja $bindir "$@" "${meson_extras[@]}"
     extra_script post meson
     unset meson_extras


### PR DESCRIPTION
Fixes #3078
Fixes #3077
Users may need to manually remove `.dll.a` files in `local*/lib` (e.g. freetype required by fontconfig)

<!--
Description

(Optional) Fixes #[issueNumber]
--->
