### PR TITLE
target `latest` tag of openal

### DIFF
--- a/build/media-suite_deps.sh
+++ b/build/media-suite_deps.sh
@@ -86,7 +86,7 @@ SOURCE_REPO_MINIZIPNG=https://github.com/zlib-ng/minizip-ng.git
 SOURCE_REPO_MPV=https://github.com/mpv-player/mpv.git
 SOURCE_REPO_MUJS=https://codeberg.org/ccxvii/mujs.git
 SOURCE_REPO_NEON=https://github.com/notroj/neon.git
-SOURCE_REPO_OPENAL=https://github.com/kcat/openal-soft.git
+SOURCE_REPO_OPENAL=https://github.com/kcat/openal-soft.git#tag=latest
 SOURCE_REPO_OPENAPV=https://github.com/AcademySoftwareFoundation/openapv.git
 SOURCE_REPO_OPENCLHEADERS=https://github.com/KhronosGroup/OpenCL-Headers.git
 SOURCE_REPO_OPUS=https://github.com/xiph/opus.git


### PR DESCRIPTION
<!--
`latest` is applied to any successful completion of the project's compilation workflow

Fixes #3084
--->

Because openal's workflow applies the `latest` tag to any successful completion of the workflow, which is honestly rather uncomplicated, this tag should always be targeted.

See: https://github.com/kcat/openal-soft/blob/a68d0c75ee2b322bb53f8c1f4d79d0f334dd9d99/.github/workflows/ci.yml#L284