### PR TITLE
Enable FFmpeg doc buliding

### DIFF
--- a/build/media-suite_compile.sh
+++ b/build/media-suite_compile.sh
@@ -2445,6 +2445,7 @@ if enabled libcdio || mpv_enabled cdda; then
 fi
 
 if [[ $ffmpeg != no ]]; then
+    do_pacman_install texinfo
     enabled libgsm && do_pacman_install gsm
     enabled libsnappy && do_pacman_install snappy
     if enabled libxvid && [[ $standalone = n ]]; then


### PR DESCRIPTION
Add a lib `texinfo` to enable ffmpeg doc building.
According to my test, building ffmpeg doc basically does not increase compile time, and will have no impact on other stuff.
Fix #3117 
<!--
Description

(Optional) Fixes #[issueNumber]
--->
